### PR TITLE
feat(server): allow to limit external search.

### DIFF
--- a/src/content/rest/__tests__/models.ts
+++ b/src/content/rest/__tests__/models.ts
@@ -5,6 +5,7 @@ const models: ModelOpts[] = [
     name: "news",
     singular: "News",
     uniqueFields: ["slug", "title"],
+    urlPath: "path/to/:slug",
     fields: {
       title: { type: "string" },
       slug: { type: "string", input: "slug" },
@@ -18,6 +19,7 @@ const models: ModelOpts[] = [
     name: "articleNews",
     singular: "News Article",
     uniqueFields: ["slug", "title"],
+    urlPath: "path/to/:slug",
     fields: {
       title: { type: "string" },
       slug: { type: "string", input: "slug" },

--- a/src/content/rest/__tests__/restApi.test.ts
+++ b/src/content/rest/__tests__/restApi.test.ts
@@ -14,10 +14,31 @@ const uploadDir = path.join(__dirname, ".uploads");
 describe("rest api", () => {
   let app: any;
   let persistence: Persistence;
+  let server: request.SuperTest<request.Test>;
+  let headers: object;
   let imageId: string;
   let productId: string;
   let newsId: string;
   const newsSlug = "foo-bar-baz";
+
+  const create = async (type: string, data: object) => {
+    const { body } = await server
+      .post(`/admin/rest/content/${type}`)
+      .set(headers)
+      .send({ data })
+      .expect(200);
+
+    return body.id;
+  };
+  const update = async (type: string, id: string, data: object) => {
+    const { body } = await server
+      .put(`/admin/rest/content/${type}/${id}`)
+      .set(headers)
+      .send(data)
+      .expect(200);
+
+    return body;
+  };
 
   beforeAll(async () => {
     const storage = new FsStorage(uploadDir);
@@ -35,30 +56,11 @@ describe("rest api", () => {
       })
     }));
 
-    const create = async (type: string, data: object) => {
-      const { body } = await server
-        .post(`/admin/rest/content/${type}`)
-        .set(headers)
-        .send({ data })
-        .expect(200);
-
-      return body.id;
-    };
-    const update = async (type: string, id: string, data: object) => {
-      const { body } = await server
-        .put(`/admin/rest/content/${type}/${id}`)
-        .set(headers)
-        .send(data)
-        .expect(200);
-
-      return body;
-    };
-
-    const { server, headers } = await login(
+    ({ server, headers } = await login(
       request(app),
       "admin@cotype.dev",
       "admin"
-    );
+    ));
 
     const imageBuffer = Buffer.from("Lorem Ipsum", "utf8");
 
@@ -203,6 +205,23 @@ describe("rest api", () => {
       return body;
     };
 
+    const search = async (
+      term: string,
+      published: boolean = true,
+      includeModels: string[] = [],
+      excludeModels: string[] = []
+    ) => {
+      const { body } = await server
+        .get(
+          `/rest/${
+            published ? "published" : "drafts"
+          }/search/content?${stringify({ term, includeModels, excludeModels })}`
+        )
+        .expect(200);
+
+      return body;
+    };
+
     const findByField = async (
       type: string,
       field: string,
@@ -298,6 +317,39 @@ describe("rest api", () => {
       });
     });
 
+    describe("search contents", () => {
+      it("create content for search", async () => {
+        await create("products", {
+          title: "Search Me Product"
+        });
+
+        await create("news", {
+          slug: "News Search Slug",
+          title: "Search Me News"
+        });
+      });
+
+      it("should find content by search", async () => {
+        expect((await search("Search Me", false)).total).toBe(2);
+        expect((await search("News Search Slug", false)).total).toBe(1);
+        expect((await search("Search Me Product", false)).total).toBe(1);
+      });
+
+      it("should find limited content by search", async () => {
+        expect((await search("Search Me", false, ["products"])).total).toBe(1);
+        expect((await search("Search Me", false, ["news"])).total).toBe(1);
+        expect(
+          (await search("Search Me", false, [], ["products", "news"])).total
+        ).toBe(0);
+        expect(
+          (await search("Search Me Product", false, [], ["products"])).total
+        ).toBe(0);
+        expect(
+          (await search("News Search Slug", false, ["news"], ["products"]))
+            .total
+        ).toBe(1);
+      });
+    });
     describe("joins", () => {
       it("should include joined references", async () => {
         await expect(

--- a/src/content/rest/__tests__/restApi.test.ts
+++ b/src/content/rest/__tests__/restApi.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import tempy from "tempy";
 import fs from "fs-extra";
 import { stringify } from "qs";
-import request, { SuperTest, Test } from "supertest";
+import request from "supertest";
 import { init, Persistence, knexAdapter } from "../../..";
 import models from "./models";
 import { login } from "../../../__tests__/util";
@@ -117,8 +117,6 @@ describe("rest api", () => {
   });
 
   describe("with content", () => {
-    let server: SuperTest<Test>;
-
     let expectedMedia: object;
     let expectedPublishedContent: object;
     let expectedDraftsContent: object;
@@ -169,8 +167,6 @@ describe("rest api", () => {
         title: "updated-news",
         slug: newsSlug
       };
-
-      server = request(app);
     });
 
     const list = async (


### PR DESCRIPTION
Allow specifying as query string parameters which models are supposed to be included or excluded in an external content search.

The rest API accepts an array of model names for the `includeModels` and `excludeModels` query parameters. 



<!-- semantish-prerelease -->
<hr /><p><time>(5/13/2019, 12:04:45 PM)</date> Pre-released as <code>@cotype/core@1.2.0-beta.e22faf3</code></p>
<!-- /semantish-prerelease -->