### PR TITLE
feat(server: external search): allow to search for all searchable content

### DIFF
--- a/src/content/rest/__tests__/models.ts
+++ b/src/content/rest/__tests__/models.ts
@@ -18,8 +18,7 @@ const models: ModelOpts[] = [
   {
     name: "articleNews",
     singular: "News Article",
-    uniqueFields: ["slug", "title"],
-    urlPath: "path/to/:slug",
+    uniqueFields: ["title"],
     fields: {
       title: { type: "string" },
       slug: { type: "string", input: "slug" },

--- a/src/content/rest/describe.ts
+++ b/src/content/rest/describe.ts
@@ -17,6 +17,7 @@ import * as Cotype from "../../../typings";
 import visitModel from "../../model/visitModel";
 import { isComparable } from "../../persistence/adapter/knex/lookup";
 import pluralize from "pluralize";
+import { searchableModelNames } from "./utils";
 
 const describeModel = (
   model: Cotype.Model | Cotype.ObjectType,
@@ -320,10 +321,7 @@ function createJoinParams(model: Model, { content: models }: Models) {
 }
 
 export default (api: OpenApiBuilder, models: Models) => {
-  const searchableModels = models.content
-    .filter(m => m.urlPath && !m.notSearchAble)
-    .map(m => m.name);
-
+  const searchableModels = searchableModelNames(models.content);
   const includeModels = {
     name: "includeModels",
     in: "query",
@@ -356,6 +354,14 @@ export default (api: OpenApiBuilder, models: Models) => {
           ...includeModels,
           name: "excludeModels",
           description: "Select models to be excluded from search."
+        },
+        {
+          name: "linkableOnly",
+          in: "query",
+          schema: {
+            type: "boolean",
+            default: true
+          }
         }
       ],
       responses: {

--- a/src/content/rest/prepareSearchResults.ts
+++ b/src/content/rest/prepareSearchResults.ts
@@ -10,7 +10,7 @@ export default function(
     .map(i => {
       const model = models.find(m => m.name === i.model);
 
-      if (!model || !model.urlPath || model.notSearchAble) {
+      if (!model || model.notSearchAble) {
         return null;
       }
       if (i.image) {

--- a/src/content/rest/utils.ts
+++ b/src/content/rest/utils.ts
@@ -1,0 +1,11 @@
+import { Model } from "../../../typings";
+
+// all models that have their own page
+export function linkableModelNames(models: Model[]) {
+  return models.filter(m => !m.notSearchAble && m.urlPath).map(m => m.name);
+}
+
+// all models that are not specifically excluded from search
+export function searchableModelNames(models: Model[]) {
+  return models.filter(m => !m.notSearchAble).map(m => m.name);
+}

--- a/src/content/routes.ts
+++ b/src/content/routes.ts
@@ -11,6 +11,7 @@ import PermissionDeniedError from "../auth/PermissionDeniedError";
 import ReferenceConflictError from "../persistence/errors/ReferenceConflictError";
 import UniqueFieldError from "../persistence/errors/UniqueFieldError";
 import ContentEventError from "../persistence/errors/ContentEventError";
+import { linkableModelNames } from "./rest/utils";
 
 export default (
   router: Router,
@@ -20,7 +21,7 @@ export default (
 ) => {
   const { content } = persistence;
   // all models that have their own page
-  const linkableModels = models.content.filter(m => m.urlPath).map(m => m.name);
+  const linkableModels = linkableModelNames(models.content);
 
   const getDataSource = (modelName: string): Cotype.DataSource => {
     return (


### PR DESCRIPTION
Allow searching for all searchable content rather than only linkable content by introducing a linkableOnly parameter to the query.

<!-- semantish-prerelease -->
<hr /><p><time>(5/13/2019, 3:47:53 PM)</date> Pre-released as <code>@cotype/core@1.3.0-beta.a6e500b</code></p>
<!-- /semantish-prerelease -->