### PR TITLE
feat(server): allow to add a description field to search results

### DIFF
--- a/src/content/convert.ts
+++ b/src/content/convert.ts
@@ -4,7 +4,8 @@ import {
   BaseUrls,
   Data,
   ContentRefs,
-  PreviewOpts
+  PreviewOpts,
+  ContentFormat
 } from "../../typings";
 import visit from "../model/visit";
 import formatQuillDelta from "./formatQuillDelta";
@@ -17,12 +18,13 @@ import getRefUrl from "./getRefUrl";
  * NOTE: Currently `richtext` is the only type that gets converted.
  * This could also be a good place to convert `media` ids to full URLs.
  */
+
 type ConvertProps = {
   content: Data;
   contentRefs?: ContentRefs;
   contentModel: Model;
   allModels: Model[];
-  contentFormat: string;
+  contentFormat: ContentFormat;
   baseUrls?: BaseUrls;
   previewOpts?: PreviewOpts;
 };
@@ -103,10 +105,11 @@ export default function convert({
         }
 
         // For external data sources content references don't exist
-        if (!contentRefs || !contentRefs[ref.model])
-          return convertedRef;
+        if (!contentRefs || !contentRefs[ref.model]) return convertedRef;
 
-        const refModel = allModels.find(m => m.name.toLowerCase() === ref.model.toLowerCase());
+        const refModel = allModels.find(
+          m => m.name.toLowerCase() === ref.model.toLowerCase()
+        );
         if (!refModel || !refModel.urlPath) return convertedRef;
 
         const allRefData = contentRefs[ref.model][ref.id];

--- a/src/content/formatQuillDelta.ts
+++ b/src/content/formatQuillDelta.ts
@@ -8,10 +8,12 @@ import { QuillDelta } from "../../typings";
 
 function plaintext(data: QuillDelta): string {
   if (!data) return "";
-  return data.ops.reduce((text, op) => {
-    if (typeof op.insert !== "string") return text + " ";
-    return text + op.insert;
-  }, "");
+  return data.ops
+    .reduce((text, op) => {
+      if (typeof op.insert !== "string") return text + " ";
+      return text + op.insert.replace(/(\r\n|\n|\r)/gm, " ");
+    }, "")
+    .trim();
 }
 
 function html(delta: QuillDelta): string {

--- a/src/content/formatQuillDelta.ts
+++ b/src/content/formatQuillDelta.ts
@@ -8,12 +8,10 @@ import { QuillDelta } from "../../typings";
 
 function plaintext(data: QuillDelta): string {
   if (!data) return "";
-  return data.ops
-    .reduce((text, op) => {
-      if (typeof op.insert !== "string") return text + " ";
-      return text + op.insert.replace(/(\r\n|\n|\r)/gm, " ");
-    }, "")
-    .trim();
+  return data.ops.reduce((text, op) => {
+    if (typeof op.insert !== "string") return text + " ";
+    return text + op.insert;
+  }, "");
 }
 
 function html(delta: QuillDelta): string {

--- a/src/content/rest/__tests__/models.ts
+++ b/src/content/rest/__tests__/models.ts
@@ -6,6 +6,7 @@ const models: ModelOpts[] = [
     singular: "News",
     uniqueFields: ["slug", "title"],
     urlPath: "path/to/:slug",
+    description: "title",
     fields: {
       title: { type: "string" },
       slug: { type: "string", input: "slug" },

--- a/src/content/rest/__tests__/restApi.test.ts
+++ b/src/content/rest/__tests__/restApi.test.ts
@@ -366,6 +366,43 @@ describe("rest api", () => {
         expect((await search(searchForProduct, opts)).total).toBe(1);
       });
 
+      it("results should contain description if path is provided in model", async () => {
+        const description = "description-test";
+
+        await create("news", {
+          slug: "foo-bar",
+          title: description
+        });
+
+        await create("articleNews", {
+          slug: "foo-bar",
+          title: description
+        });
+
+        expect(
+          (await search(description, {
+            published: false,
+            linkableOnly: false
+          })).total
+        ).toBe(2);
+
+        expect(
+          (await search(description, {
+            published: false,
+            linkableOnly: false,
+            includeModels: ["news"]
+          })).items[0]
+        ).toMatchObject({ description });
+
+        expect(
+          (await search(description, {
+            published: false,
+            linkableOnly: false,
+            includeModels: ["articleNews"]
+          })).items[0]
+        ).not.toMatchObject({ description });
+      });
+
       it("should find only linkable content by search", async () => {
         expect(
           (await search(searchForAllContent, {

--- a/src/content/rest/__tests__/restApi.test.ts
+++ b/src/content/rest/__tests__/restApi.test.ts
@@ -338,8 +338,9 @@ describe("rest api", () => {
       const searchForProduct = "Search Me Product";
       const searchForNews = "News Search Slug";
       const searchForArticleNews = "ArticleNews Search Slug";
+      const description = "description-test";
 
-      it("create content for search", async () => {
+      beforeAll(async () => {
         await create("products", {
           title: searchForProduct
         });
@@ -352,6 +353,16 @@ describe("rest api", () => {
         await create("articleNews", {
           slug: searchForArticleNews,
           title: "Search Me ArticleNews"
+        });
+
+        await create("news", {
+          slug: "foo-bar",
+          title: description
+        });
+
+        await create("articleNews", {
+          slug: "foo-bar",
+          title: description
         });
       });
 
@@ -367,25 +378,6 @@ describe("rest api", () => {
       });
 
       it("results should contain description if path is provided in model", async () => {
-        const description = "description-test";
-
-        await create("news", {
-          slug: "foo-bar",
-          title: description
-        });
-
-        await create("articleNews", {
-          slug: "foo-bar",
-          title: description
-        });
-
-        expect(
-          (await search(description, {
-            published: false,
-            linkableOnly: false
-          })).total
-        ).toBe(2);
-
         expect(
           (await search(description, {
             published: false,
@@ -393,14 +385,16 @@ describe("rest api", () => {
             includeModels: ["news"]
           })).items[0]
         ).toMatchObject({ description });
+      });
 
+      it("should not contain description in result when no path is provided in model", async () => {
         expect(
           (await search(description, {
             published: false,
             linkableOnly: false,
             includeModels: ["articleNews"]
-          })).items[0]
-        ).not.toMatchObject({ description });
+          })).items[0].description
+        ).toBe(undefined);
       });
 
       it("should find only linkable content by search", async () => {

--- a/src/content/rest/describe.ts
+++ b/src/content/rest/describe.ts
@@ -383,7 +383,8 @@ export default (api: OpenApiBuilder, models: Models) => {
                     properties: {
                       id: string,
                       title: string,
-                      image: string
+                      image: string,
+                      description: string
                     }
                   })
                 }

--- a/src/content/rest/prepareSearchResults.ts
+++ b/src/content/rest/prepareSearchResults.ts
@@ -18,6 +18,7 @@ export default function(
       }
       return {
         id: i.id,
+        description: i.description,
         image: {
           _id: i.image,
           _ref: "media",

--- a/src/persistence/ContentPersistence.ts
+++ b/src/persistence/ContentPersistence.ts
@@ -19,7 +19,7 @@ function findValueByPath(path: string | undefined, data: Cotype.Data) {
   const titlePath = path.split(".");
 
   const title = (titlePath.reduce(
-    (obj, key) => (obj && obj[key] !== "undefined" ? obj[key] : undefined),
+    (obj, key) => (obj ? obj[key] : undefined),
     data
   ) as unknown) as (string | undefined);
 

--- a/typings/entities.d.ts
+++ b/typings/entities.d.ts
@@ -15,6 +15,8 @@ export type ListOpts = {
   };
 };
 
+export type ContentFormat = "html" | "plaintext" | "json" | "markdown";
+
 export type MediaListOpts = {
   offset?: string | number;
   limit?: string | number;
@@ -188,6 +190,7 @@ export type SearchResultItem = {
   id: string;
   model: string;
   title: string;
+  description?: string;
   image: string | undefined;
   url: string;
 };

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -202,11 +202,12 @@ export type ModelOpts = {
   fields: {
     [key: string]: Field & { unique?: boolean };
   };
-  customQuery?:{
-    [s:string]: string;
-  }
+  customQuery?: {
+    [s: string]: string;
+  };
   uniqueFields?: string[];
   title?: string;
+  description?: string;
   image?: string;
   group?: string;
   notSearchAble?: boolean;


### PR DESCRIPTION
Allow defining a path to a description field in the model, similar to the already existing title path. If the path is set, the value of that field will be included in a content search response as description.

<!-- semantish-prerelease -->
<hr /><p><time>(5/16/2019, 9:48:52 AM)</date> Pre-released as <code>@cotype/core@1.7.0-beta.8bfe65a</code></p>
<!-- /semantish-prerelease -->