### PR TITLE
fix: don't encode media ids 

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -17,10 +17,10 @@ class ApiError extends Error {
   }
 }
 
-function encodeMediaId(s: string) {
+function prepareMediaId(s: string) {
   // NOTE: We add a trailing slash to the URL as some caching proxies otherwise
-  // think we are requesting a static image resouce and drop the Cookie header.
-  return encodeURIComponent(s) + "/";
+  // think we are requesting a static image resource and drop the Cookie header.
+  return s + "/";
 }
 
 class Api {
@@ -164,15 +164,15 @@ class Api {
   }
 
   loadMedia(id: string): Promise<Cotype.Media> {
-    return this.get(`/media/${encodeMediaId(id)}`);
+    return this.get(`/media/${prepareMediaId(id)}`);
   }
 
   updateMedia(id: string, meta: Cotype.ImageMeta): Promise<void> {
-    return this.post(`/media/${encodeMediaId(id)}`, meta);
+    return this.post(`/media/${prepareMediaId(id)}`, meta);
   }
 
   deleteMedia(id: string): Promise<void> {
-    return this.del(`/media/${encodeMediaId(id)}`);
+    return this.del(`/media/${prepareMediaId(id)}`);
   }
 }
 

--- a/src/media/routes.ts
+++ b/src/media/routes.ts
@@ -75,29 +75,32 @@ export default function routes(
     res.json(list);
   });
 
-  router.get("/admin/rest/media/:id", async (req, res) => {
+  router.get("/admin/rest/media/*", async (req, res) => {
     const { principal, params } = req;
-    const id = params.id;
+    const id = prepareMediaId(params[0]);
+
     const [data] = await media.load(principal, [id]);
+
+    if (!data) return res.status(404).end();
     res.json(data);
   });
 
-  router.post("/admin/rest/media/:id", async (req, res) => {
+  router.post("/admin/rest/media/*", async (req, res) => {
     const { principal, params, body } = req;
-    const id = params.id;
+    const id = prepareMediaId(params[0]);
 
     const data = await media.update(principal, id, body);
 
     if (data) {
       res.status(200).end();
     } else {
-      res.status(500).end();
+      res.status(400).end();
     }
   });
 
-  router.delete("/admin/rest/media/:id", async (req, res) => {
+  router.delete("/admin/rest/media/*", async (req, res) => {
     const { principal, params } = req;
-    const id = params.id;
+    const id = prepareMediaId(params[0]);
     try {
       await media.delete(principal, id);
       storage.remove(id);
@@ -111,4 +114,9 @@ export default function routes(
       }
     }
   });
+}
+
+// Remove trailing slash
+function prepareMediaId(id: string) {
+  return id.replace(/\/$/g, "");
 }

--- a/src/persistence/MediaPersistence.ts
+++ b/src/persistence/MediaPersistence.ts
@@ -35,9 +35,7 @@ export default class MediaPeristence {
     id: string,
     data: Cotype.Media
   ): Promise<Cotype.Settings> {
-    // checkPermissions(principal, model, Permission.edit);
-    const media = await this.adapter.update(id, data);
-    return media;
+    return this.adapter.update(id, data);
   }
 
   load(principal: Cotype.Principal, ids: string[]) {

--- a/src/persistence/adapter/knex/KnexMedia.ts
+++ b/src/persistence/adapter/knex/KnexMedia.ts
@@ -91,7 +91,7 @@ export default class KnexMedia implements MediaAdapter {
       args.tags = JSON.stringify(args.tags);
     }
 
-    return await this.knex("media")
+    return this.knex("media")
       .where({ id })
       .update({ ...args, search });
   }


### PR DESCRIPTION
encoded slashes may lead to problems with web servers, e.g. Apache.

<!-- semantish-prerelease -->
<hr /><p><time>(5/23/2019, 2:28:44 PM)</date> Pre-released as <code>@cotype/core@1.9.1-beta.4da4667</code></p>
<!-- /semantish-prerelease -->