### PR TITLE
feat(server): add fulltext-search to list routes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5661,11 +5661,6 @@
       "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
-    "object-to-querystring": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/object-to-querystring/-/object-to-querystring-1.0.8.tgz",
-      "integrity": "sha512-dsef73lwN0pgSwil54u+XL7xpECqXrvYcPROIPZvBoB5Qt86XEMjjI8JFq2k5IIcUTu2EHaj5Sja576avRXkpg=="
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,6 @@
     "javascript-time-ago": "^2.0.1",
     "moment": "^2.24.0",
     "mudder": "^1.0.4",
-    "object-to-querystring": "^1.0.8",
     "quill-delta": "^4.2.0",
     "rc-input-number": "^4.4.0",
     "react": "^16.8.4",

--- a/client/src/Edit/elements/ReferenceInput.tsx
+++ b/client/src/Edit/elements/ReferenceInput.tsx
@@ -137,8 +137,8 @@ export default class ReferenceInput extends Component<Props, State> {
       models: models.length ? models : undefined
     });
 
-    return api.get(`/${type}?${queryString}`).then(res => {
-      if (res) this.setState({ items: res.items });
+    return api.get(`/${type}?${queryString}`).then(({ items }) => {
+      this.setState({ items });
     });
   };
 

--- a/client/src/Edit/elements/ReferenceInput.tsx
+++ b/client/src/Edit/elements/ReferenceInput.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from "react";
 import styled, { css, cx } from "react-emotion";
 import { FieldProps } from "formik";
-import query from "object-to-querystring";
+import { stringify } from "qs";
 import { inputClass } from "../../common/styles";
 import Autocomplete from "../../common/Autocomplete";
 import ImageCircle from "../../common/ImageCircle";
@@ -130,24 +130,16 @@ export default class ReferenceInput extends Component<Props, State> {
 
   fetchItems = opts => {
     const { type, models } = this.props;
-    const [firstModel, ...otherModels] = models;
 
-    const queryString = query({
+    const queryString = stringify({
       ...opts,
       linkable: models.length === 0,
-      models: otherModels && otherModels.length ? models : undefined
+      models: models.length ? models : undefined
     });
 
-    // if reference has only one options, use list instead of search
-    return api
-      .get(
-        `/${type}${
-          models.length === 0 || otherModels.length > 0 ? "" : `/${firstModel}/`
-        }${queryString}`
-      )
-      .then(res => {
-        if (res) this.setState({ items: res.items });
-      });
+    return api.get(`/${type}?${queryString}`).then(res => {
+      if (res) this.setState({ items: res.items });
+    });
   };
 
   fetchItem = refObj => {

--- a/client/src/Edit/elements/SingleReferenceInput.tsx
+++ b/client/src/Edit/elements/SingleReferenceInput.tsx
@@ -88,8 +88,10 @@ export default class SingleReferenceInput extends Component<Props, State> {
   fetchItems = opts => {
     const { type, model } = this.props;
 
+    const queryString = stringify(opts);
+
     return api
-      .get(`/${type}/${model}?${stringify(opts)}`)
+      .get(`/${type}/${model}${queryString ? "?" + queryString : ""}`)
       .then(({ items }) => this.setState({ items }));
   };
 

--- a/client/src/Edit/elements/SingleReferenceInput.tsx
+++ b/client/src/Edit/elements/SingleReferenceInput.tsx
@@ -1,12 +1,12 @@
 import React, { Component } from "react";
 import styled, { css } from "react-emotion";
 import { FieldProps } from "formik";
-import query from "object-to-querystring";
 import { inputClass } from "../../common/styles";
 import Autocomplete from "../../common/Autocomplete";
 import ImageCircle from "../../common/ImageCircle";
 import api from "../../api";
 import { required } from "./validation";
+import { stringify } from "qs";
 
 const Root = styled("div")`
   ${inputClass} padding: 0;
@@ -86,8 +86,9 @@ export default class SingleReferenceInput extends Component<Props, State> {
 
   fetchItems = opts => {
     const { type, model } = this.props;
+
     return api
-      .get(`/${type}/${model}/${query(opts)}`)
+      .get(`/${type}/${model}?${stringify(opts)}`)
       .then(({ items }) => this.setState({ items }));
   };
 

--- a/client/src/Edit/elements/SingleReferenceInput.tsx
+++ b/client/src/Edit/elements/SingleReferenceInput.tsx
@@ -72,8 +72,7 @@ export default class SingleReferenceInput extends Component<Props, State> {
   }
 
   onInputValueChange = (inputValue, downshift) => {
-    if (inputValue)
-      this.fetchItems({ search: { term: inputValue, scope: "title" } });
+    if (inputValue) this.fetchItems({ q: inputValue });
     else this.fetchItems({});
   };
 

--- a/client/src/Edit/elements/SingleReferenceInput.tsx
+++ b/client/src/Edit/elements/SingleReferenceInput.tsx
@@ -72,7 +72,8 @@ export default class SingleReferenceInput extends Component<Props, State> {
   }
 
   onInputValueChange = (inputValue, downshift) => {
-    if (inputValue) this.fetchItems({ q: inputValue });
+    if (inputValue)
+      this.fetchItems({ search: { term: inputValue, scope: "title" } });
     else this.fetchItems({});
   };
 

--- a/client/src/List/List.tsx
+++ b/client/src/List/List.tsx
@@ -157,7 +157,7 @@ export default class ListWithItems extends Component<Props, State> {
     api
       .list(
         model,
-        { offset, limit, q: searchTerm },
+        { offset, limit, search: { term: searchTerm, scope: "title" } },
         this.createFilterCriterita()
       )
       .then(res => {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -95,7 +95,7 @@ class Api {
 
   list(
     model: Cotype.Model,
-    listOpts: { q?: string } & Omit<Cotype.ListOpts, "search">,
+    listOpts: Cotype.ListOpts,
     criteria: Cotype.Criteria = {}
   ): Promise<Cotype.ListChunk<Cotype.Item>> {
     const { type, name } = model;

--- a/client/typings/untyped-modules.d.ts
+++ b/client/typings/untyped-modules.d.ts
@@ -2,7 +2,6 @@ declare module "@navjobs/upload";
 declare module "color-hash";
 declare module "javascript-time-ago";
 declare module "javascript-time-ago/locale/en";
-declare module "object-to-querystring";
 declare module "react-circular-progressbar";
 declare module "react-day-picker/moment";
 declare module "react-time-ago";

--- a/src/__tests__/externalDataSource.test.ts
+++ b/src/__tests__/externalDataSource.test.ts
@@ -139,7 +139,7 @@ describe("external data source support", () => {
         .query({
           offset: "2",
           limit: "500",
-          q: "foo"
+          search: { term: "foo", scope: "title" }
         })
         .expect(200);
 
@@ -149,7 +149,7 @@ describe("external data source support", () => {
         expect.objectContaining({
           offset: "2",
           limit: "500",
-          search: { term: "foo" }
+          search: { term: "foo", scope: "title" }
         }),
         undefined
       );

--- a/src/content/describe.ts
+++ b/src/content/describe.ts
@@ -10,6 +10,7 @@ import {
   body,
   empty
 } from "../api/oapi";
+import { listSearchParams } from "./rest/describe";
 
 const tags = ["Content"];
 const produces = ["application/json"];
@@ -52,7 +53,7 @@ export default (api: OpenApiBuilder) => {
     get: {
       summary: "List contents of the give type",
       operationId: "listContents",
-      parameters: [param("type", { schema: string })],
+      parameters: [param("type", { schema: string }), listSearchParams],
       tags,
       produces,
       responses: {

--- a/src/content/rest/__tests__/restApi.test.ts
+++ b/src/content/rest/__tests__/restApi.test.ts
@@ -173,13 +173,13 @@ describe("rest api", () => {
 
     const list = async (
       type: string,
-      join: object = {},
+      params: object = {},
       published: boolean = true
     ) => {
       const { body } = await server
         .get(
           `/rest/${published ? "published" : "drafts"}/${type}?${stringify(
-            join
+            params
           )}`
         )
         .expect(200);
@@ -293,6 +293,55 @@ describe("rest api", () => {
       it("should list news", async () => {
         const news = await list("news", {}, true);
         await expect(news.total).toBe(1);
+      });
+
+      it("should list news with search criteria", async () => {
+        await create("news", {
+          slug: "lololorem-ipipipsum",
+          title: "foo-new-title"
+        });
+
+        await expect(
+          (await list(
+            "news",
+            { search: { term: "foo-new-t", scope: "title" } },
+            false
+          )).total
+        ).toBe(1);
+
+        await expect(
+          (await list(
+            "news",
+            { search: { term: "lololor", scope: "global" } },
+            false
+          )).total
+        ).toBe(1);
+      });
+
+      it("should not list news with wrong search criteria", async () => {
+        await expect(
+          (await list(
+            "news",
+            { search: { term: "lololor", scope: "title" } },
+            false
+          )).total
+        ).toBe(0);
+
+        await expect(
+          (await list(
+            "news",
+            { search: { term: "foo-new-txx", scope: "title" } },
+            false
+          )).total
+        ).toBe(0);
+
+        await expect(
+          (await list(
+            "news",
+            { search: { term: "lololor-xx", scope: "global" } },
+            false
+          )).total
+        ).toBe(0);
       });
 
       it("should get published news by id", async () => {

--- a/src/content/rest/describe.ts
+++ b/src/content/rest/describe.ts
@@ -20,6 +20,24 @@ import { isComparable } from "../../persistence/adapter/knex/lookup";
 import pluralize from "pluralize";
 import { searchableModelNames } from "./utils";
 
+export const listSearchParams: ParameterObject = {
+  in: "query",
+  name: `search`,
+  style: "deepObject",
+  explode: true,
+  schema: {
+    type: "object",
+    properties: {
+      term: string,
+      scope: {
+        type: "string",
+        enum: ["title", "global"],
+        default: "global"
+      }
+    }
+  }
+};
+
 const describeModel = (
   model: Cotype.Model | Cotype.ObjectType,
   prefix = "",
@@ -462,7 +480,11 @@ export default (api: OpenApiBuilder, models: Models) => {
         summary: singleton ? `Load ${singularName}` : `List ${pluralName}`,
         operationId: singleton ? `load_${singularName}` : `list_${pluralName}`,
         tags,
-        parameters: createQueryParams(model).concat(commonParams),
+        parameters: [
+          ...createQueryParams(model),
+          ...commonParams,
+          listSearchParams
+        ],
         responses: {
           "200": {
             description: singleton

--- a/src/content/rest/routes.ts
+++ b/src/content/rest/routes.ts
@@ -6,7 +6,8 @@ import {
   ExternalDataSource,
   BaseUrls,
   Principal,
-  Join
+  Join,
+  ListOpts
 } from "../../../typings";
 
 import { Router } from "express";
@@ -163,7 +164,18 @@ export default (
       // List
       router.get(`/rest/${mode}/${type}`, async (req, res) => {
         const { principal, query } = req;
-        const { limit = 50, offset = 0, join, order, orderBy, ...rest } = query;
+        const {
+          q,
+          title,
+          limit = 50,
+          offset = 0,
+          join,
+          order,
+          orderBy,
+          ...rest
+        } = query;
+        const search = { term: q, title };
+        const opts: ListOpts = { search, offset, limit, order, orderBy };
 
         checkPermissionToJoin(req.principal, join);
 
@@ -176,7 +188,7 @@ export default (
           const { items, total, _refs } = await dataSource.find(
             principal,
             model,
-            { limit: 1, offset: 0 },
+            opts,
             format,
             join,
             criteria,
@@ -197,7 +209,7 @@ export default (
           const { total, items, _refs } = await dataSource.find(
             principal,
             model,
-            { limit, offset, order, orderBy },
+            opts,
             format,
             join,
             criteria,

--- a/src/content/rest/routes.ts
+++ b/src/content/rest/routes.ts
@@ -165,8 +165,7 @@ export default (
       router.get(`/rest/${mode}/${type}`, async (req, res) => {
         const { principal, query } = req;
         const {
-          q,
-          title,
+          search = {},
           limit = 50,
           offset = 0,
           join,
@@ -174,7 +173,7 @@ export default (
           orderBy,
           ...rest
         } = query;
-        const search = { term: q, title };
+
         const opts: ListOpts = { search, offset, limit, order, orderBy };
 
         checkPermissionToJoin(req.principal, join);

--- a/src/content/routes.ts
+++ b/src/content/routes.ts
@@ -58,9 +58,8 @@ export default (
   router.get("/admin/rest/content/:modelName", async (req, res) => {
     const { principal, params, query } = req;
     const { modelName } = params;
-    const { q, limit = 50, offset = 0, ...rest } = query;
+    const { search = {}, limit = 50, offset = 0, ...rest } = query;
     const criteria = rest && Object.keys(rest).length ? rest : undefined;
-    const search = q ? { term: q } : undefined;
     const opts: Cotype.ListOpts = { search, offset, limit };
     const model = getModel(modelName);
 

--- a/src/persistence/ContentPersistence.ts
+++ b/src/persistence/ContentPersistence.ts
@@ -428,10 +428,10 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
     criteria?: Cotype.Criteria,
     previewOpts?: Cotype.PreviewOpts
   ): Promise<Cotype.ListChunkWithRefs<Cotype.Content>> {
-    const items = await this.adapter.find(
+    const items = await this.adapter.list(
       model,
-      opts,
       this.models,
+      opts,
       criteria,
       previewOpts
     );
@@ -468,7 +468,7 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
     criteria?: Cotype.Criteria,
     previewOpts?: Cotype.PreviewOpts
   ): Promise<Cotype.ListChunk<Cotype.Content>> {
-    return this.adapter.find(model, opts, this.models, criteria, previewOpts);
+    return this.adapter.list(model, this.models, opts, criteria, previewOpts);
   }
 
   async search(

--- a/src/persistence/adapter/index.ts
+++ b/src/persistence/adapter/index.ts
@@ -37,8 +37,9 @@ export type ContentAdapter = {
   list(
     model: Cotype.Model,
     models: Cotype.Model[],
-    listOpts: Cotype.ListOpts,
-    criteria?: Cotype.Criteria
+    listOpts?: Cotype.ListOpts,
+    criteria?: Cotype.Criteria,
+    previewOpts?: Cotype.PreviewOpts
   ): Promise<Cotype.ListChunk<Cotype.Content>>;
   load(
     model: Cotype.Model,
@@ -79,15 +80,6 @@ export type ContentAdapter = {
     term: string,
     exact: boolean,
     opts: Cotype.ListOpts,
-    previewOpts?: Cotype.PreviewOpts
-  ): Promise<Cotype.ListChunk<Cotype.Content>>;
-
-  // For the read-only API:
-  find(
-    model: Cotype.Model,
-    opts: Cotype.ListOpts,
-    models: Cotype.Model[],
-    criteria?: Cotype.Criteria,
     previewOpts?: Cotype.PreviewOpts
   ): Promise<Cotype.ListChunk<Cotype.Content>>;
 };

--- a/typings/entities.d.ts
+++ b/typings/entities.d.ts
@@ -11,7 +11,8 @@ export type ListOpts = {
   models?: string[];
   search?: {
     prop?: string;
-    term: string;
+    term?: string;
+    scope?: "title" | "global";
   };
 };
 


### PR DESCRIPTION
Allow adding search criteria as a query parameter to admin- and rest content-list-routes in following structure: `search: { term: string, scope: "global" | "title" }`. This way you can use full-text search combined with other limiting list criteria. 

<!-- semantish-prerelease -->
<hr /><p><time>(5/27/2019, 12:57:28 PM)</date> Pre-released as <code>@cotype/core@1.12.0-beta.9de9ff4</code></p>
<!-- /semantish-prerelease -->