### PR TITLE
Try to make media e2e more stable

### DIFF
--- a/cypress/integration/mediaHandling.spec.ts
+++ b/cypress/integration/mediaHandling.spec.ts
@@ -78,7 +78,7 @@ context("Media", () => {
     media.tile(image1Name).should("have.length", 1);
 
     media.delete(image1Name);
-    media.tile(image1Name).should("have.length", 0);
+    media.caption(image1Name).should("have.length", 0);
   });
 
   it("displays and saves media details", () => {

--- a/cypress/pages/content.ts
+++ b/cypress/pages/content.ts
@@ -1,3 +1,3 @@
-import List from "./lists/List";
+import Content from "./lists/Content";
 
-export default new List();
+export default new Content();

--- a/cypress/pages/lists/Content.ts
+++ b/cypress/pages/lists/Content.ts
@@ -1,0 +1,7 @@
+import List from "./List";
+
+export default class Content extends List {
+  upload(file: Cypress.FileData) {
+    cy.testable("upload-zone").upload(file, { subjectType: "drag-n-drop" });
+  }
+}

--- a/cypress/pages/media.ts
+++ b/cypress/pages/media.ts
@@ -1,0 +1,59 @@
+import { testableSelector } from "../support/commands";
+
+function details(fileName: string) {
+  const element = () => {
+    return cy.testableContains("overlay", fileName);
+  };
+  return {
+    should: element().should,
+    alt() {
+      return element().find(testableSelector("meta-data-alt"));
+    },
+    setAlt(text: string) {
+      this.alt().type(text);
+    },
+    addTag(text: string) {
+      element()
+        .find(testableSelector("chip-list-input"))
+        .type(text)
+        .siblings("button")
+        .click();
+    },
+    tag(text: string) {
+      return element().contains("div", text);
+    },
+    deleteTag(text: string) {
+      this.tag(text)
+        .children("button")
+        .click();
+    },
+    save() {
+      element()
+        .contains("button", "Save")
+        .click();
+    }
+  };
+}
+
+export default {
+  upload(files: Cypress.FileData | Cypress.FileData[]) {
+    cy.testable("upload-zone").upload(files, { subjectType: "drag-n-drop" });
+  },
+  tile(fileName: string) {
+    return cy
+      .testableContains("media-caption", fileName, { timeout: 20000 })
+      .closest(testableSelector("media-tile"));
+  },
+  delete(fileName: string) {
+    this.tile(fileName)
+      .find(testableSelector("media-delete"))
+      .click();
+  },
+  details(fileName: string) {
+    this.tile(fileName)
+      .find(testableSelector("media-details"))
+      .click();
+
+    return details(fileName);
+  }
+};

--- a/cypress/pages/media.ts
+++ b/cypress/pages/media.ts
@@ -39,10 +39,11 @@ export default {
   upload(files: Cypress.FileData | Cypress.FileData[]) {
     cy.testable("upload-zone").upload(files, { subjectType: "drag-n-drop" });
   },
+  caption(fileName: string) {
+    return cy.testableContains("media-caption", fileName, { timeout: 20000 });
+  },
   tile(fileName: string) {
-    return cy
-      .testableContains("media-caption", fileName, { timeout: 20000 })
-      .closest(testableSelector("media-tile"));
+    return this.caption(fileName).closest(testableSelector("media-tile"));
   },
   delete(fileName: string) {
     this.tile(fileName)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -10,7 +10,7 @@ type User = {
   name: string;
 };
 
-function testableSelector(id) {
+export function testableSelector(id) {
   return `[data-test-id="${id}"]`;
 }
 


### PR DESCRIPTION
in order to re-use selectors, have a default timeout

this is an attempt to make the tests more stable

 - moved selectors out of the test file into `media` page helper
 - added increased timeout for media-tile selection
 - made test not depend on state from prior tests
 - added actual assertions (`should(...)`)
 - use `testableContains` for tile lookup

PTAL @dlehmhus 