### PR TITLE
feat: allow longer text in mysql

### DIFF
--- a/knex_migrations/20190612141100_allowLongerText.js
+++ b/knex_migrations/20190612141100_allowLongerText.js
@@ -1,0 +1,24 @@
+exports.up = async function(knex, Promise) {
+  const { client } = knex.client.config;
+
+  if (client === "mysql") {
+    await knex.schema.alterTable("content_revisions", table => {
+      table.text("data", "mediumtext").alter();
+    });
+    await knex.schema.alterTable("content_search", table => {
+      table.text("text", "mediumtext").alter();
+    });
+  }
+};
+
+exports.down = async function(knex, Promise) {
+  const { client } = knex.client.config;
+  if (client === "mysql") {
+    await knex.schema.alterTable("content_revisions", table => {
+      table.text("data", "text").alter();
+    });
+    await knex.schema.alterTable("content_search", table => {
+      table.text("data", "text").alter();
+    });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export async function init(opts: Opts) {
 
   const app = express();
 
-  app.use(express.json());
+  app.use(express.json({ limit: "1mb" }));
   app.use(session(opts.sessionOpts));
 
   app.all("/status", (req, res) => {


### PR DESCRIPTION
The default length of a text column is 65,535 chars. For certain contents this is not enough.
For that reason we should alter to text column type to mediumtext, which allows for text up to 16,777,215 chars.

<!-- semantish-prerelease -->
<hr /><p><time>(6/14/2019, 4:49:49 PM)</date> Pre-released as <code>@cotype/core@1.15.0-beta.727879a</code></p>
<!-- /semantish-prerelease -->