### PR TITLE
fix(server: formatQuillDelta): if data is a string, return without formating

### DIFF
--- a/src/content/formatQuillDelta.ts
+++ b/src/content/formatQuillDelta.ts
@@ -31,5 +31,10 @@ export const formats = Object.keys(formatters);
 export default (data: QuillDelta, format: string): any => {
   const f = formatters[format];
   if (!f) throw new Error(`Invalid richtext format: ${format}`);
+  /* In the case you switch from type `string` to type `richtext`
+    data will be provided but not in the correct format.
+    In the future such a problem should be solved with a data migration.
+  */
+  if (typeof data === "string") return data;
   return f(data);
 };


### PR DESCRIPTION
If you switch any other type to a field of type richtext, the server will run into trouble formatting that data.

<!-- semantish-prerelease -->
<hr /><p><time>(6/26/2019, 3:43:18 PM)</date> Pre-released as <code>@cotype/core@1.16.2-beta.f2dd69d</code></p>
<!-- /semantish-prerelease -->