### PR TITLE
fix(client: MediaGallery): don't render topbar inside the dropzone

### DIFF
--- a/client/src/Media/Topbar.tsx
+++ b/client/src/Media/Topbar.tsx
@@ -113,7 +113,7 @@ const OrderButton = styled("div")`
   }
 `;
 
-type Props = {
+export type Props = {
   onFilterChange: (filter: string) => void;
   onSearch: (query: string) => void;
   filters: Array<{ label: string; value: string }>;

--- a/client/src/Media/__tests__/Topbar.test.tsx
+++ b/client/src/Media/__tests__/Topbar.test.tsx
@@ -1,0 +1,82 @@
+import mock from "xhr-mock";
+import React from "react";
+import { render, fireEvent, wait } from "@testing-library/react";
+import api from "../../api";
+import { UploadProvider, createXhrClient } from "react-use-upload";
+import Topbar, { Props as TopbarProps } from "../Topbar";
+
+const FILTERS = [
+  { label: "All", value: "all" },
+  { label: "Media", value: "media" }
+];
+const ORDERS = [
+  { label: "Date", value: "date" },
+  { label: "Name", value: "name" }
+];
+
+const createFile = (name: string, size: number, type: string) => {
+  const file = new File([], name, { type });
+  Object.defineProperty(file, "size", {
+    get() {
+      return size;
+    }
+  });
+  return file;
+};
+
+function renderTopbar(customProps: Partial<TopbarProps> = {}) {
+  const props = {
+    onFilterChange: jest.fn(),
+    onSearch: jest.fn(),
+    filters: FILTERS,
+    orderBys: ORDERS,
+    onOrderByChange: jest.fn(),
+    onOrderChange: jest.fn(),
+    onUpload: jest.fn(),
+    onUploadProgress: jest.fn()
+  };
+
+  const queries = render(
+    <UploadProvider client={createXhrClient({ baseUrl: api.baseURI })}>
+      <div>
+        <Topbar {...props} />
+      </div>
+    </UploadProvider>
+  );
+
+  return { ...queries, props };
+}
+
+describe("UploadZone", () => {
+  let files: File[];
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      /* https://github.com/facebook/react/issues/14769 */
+    });
+    files = [createFile("file1.pdf", 1111, "application/pdf")];
+    mock.setup();
+  });
+  afterEach(() => mock.teardown());
+
+  it("uploads file", async () => {
+    const {
+      getByText,
+      props: { onUpload, onUploadProgress }
+    } = renderTopbar();
+
+    mock.post("/rest/upload", {
+      status: 200,
+      body: "Foo"
+    });
+
+    let uploadButton = getByText("Upload New");
+    uploadButton = uploadButton.closest("button") as HTMLElement;
+    const uploadInput = uploadButton.nextSibling as HTMLElement;
+    fireEvent.change(uploadInput, { target: { files } });
+
+    await wait(() =>
+      expect(onUploadProgress).toHaveBeenCalledWith(expect.any(Number))
+    );
+    await wait(() => expect(onUpload).toHaveBeenCalledWith("Foo"));
+  });
+});

--- a/client/src/Media/index.tsx
+++ b/client/src/Media/index.tsx
@@ -65,6 +65,7 @@ type State = {
   order?: string;
   search?: string;
   filters: Array<{ label: string; value: string }>;
+  topbarProgress: number | undefined;
 };
 type Props = {
   model?: object;
@@ -92,7 +93,8 @@ export default class Media extends Component<Props, State> {
     editable: false,
     orderBy: "created_at",
     order: "desc",
-    filters: FilterTypes
+    filters: FilterTypes,
+    topbarProgress: undefined
   };
 
   constructor(props: Props) {
@@ -251,7 +253,8 @@ export default class Media extends Component<Props, State> {
       details,
       editable,
       conflictingItems,
-      filters
+      filters,
+      topbarProgress
     } = this.state;
     return (
       <Root {...testable("upload-zone")}>
@@ -273,25 +276,31 @@ export default class Media extends Component<Props, State> {
             fetchMediaItem={this.fetchMediaItem}
           />
         )}
+        <Topbar
+          onUpload={this.onUpload}
+          onUploadProgress={progress =>
+            this.setState({ topbarProgress: progress })
+          }
+          filters={filters}
+          onFilterChange={this.onFilterChange}
+          onOrderByChange={this.onOrderByChange}
+          onSearch={this.onSearch}
+          orderBys={OrderByTypes}
+          onOrderChange={this.onOrderChange}
+        />
         <UploadZone
           className={className}
           activeClass={activeClass}
           onUpload={this.onUpload}
-          render={({ progress, complete, onFiles }: any) => {
-            const itemCount = progress && !complete ? total + 1 : total;
+          render={({ progress, onFiles }: any) => {
+            const itemCount =
+              !!progress || !!topbarProgress ? total + 1 : total;
             const data =
-              progress && !complete ? [{ progress }, ...items] : items;
+              !!progress || !!topbarProgress
+                ? [{ progress: progress || topbarProgress }, ...items]
+                : items;
             return (
               <Fragment>
-                <Topbar
-                  onAdd={onFiles}
-                  filters={filters}
-                  onFilterChange={this.onFilterChange}
-                  onOrderByChange={this.onOrderByChange}
-                  onSearch={this.onSearch}
-                  orderBys={OrderByTypes}
-                  onOrderChange={this.onOrderChange}
-                />
                 <Main>
                   <Gallery
                     count={itemCount}


### PR DESCRIPTION
The HOC `UploadZone` rerenders whenever the prop `render` changes. https://github.com/cotype/core/blob/cd08d46a4f0af5c08cd08d7b7ae9c9702940f0c4/client/src/Media/UploadZone.tsx#L30 Since the `Topbar` uses state, `render` will change on every state change, thus making the `Topbar` or in fact any stateful component unusable inside the `UploadZone`.

<!-- semantish-prerelease -->
<hr /><p><time>(7/12/2019, 3:50:44 PM)</date> Pre-released as <code>@cotype/core@1.16.6-beta.9648bd9</code></p>
<!-- /semantish-prerelease -->