### PR TITLE
feat(server: rest) allow to specify response fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
       "!**/lib/**",
       "!**/node_modules/**",
       "!**/demo/**"
+    ],
+    "watchPathIgnorePatterns": [
+      "node_modules"
     ]
   }
 }

--- a/src/content/rest/__tests__/pickResponseData.test.ts
+++ b/src/content/rest/__tests__/pickResponseData.test.ts
@@ -1,0 +1,171 @@
+import {
+  Content,
+  ContentWithRefs,
+  ListChunkWithRefs,
+  Meta,
+  ModelOpts,
+  Model
+} from "../../../../typings";
+import pickFieldsFromResultData from "../pickFieldsFromResultData";
+
+const contentRef = {
+  _content: "document",
+  _id: 853,
+  _ref: "content"
+};
+
+const mediaRef = {
+  id: "abc.pdf",
+  size: 12345
+} as Meta;
+
+const model: ModelOpts = {
+  name: "TestModel",
+  singular: "Foo",
+  plural: "Foos",
+  fields: {
+    foo: { type: "string" },
+    bar: {
+      type: "object",
+      fields: {
+        bar: { type: "number" }
+      }
+    },
+    fooBar: {
+      type: "media"
+    },
+    bazn: {
+      type: "content",
+      models: [contentRef._content]
+    }
+  }
+};
+
+const data: Content = {
+  id: "1",
+  data: {
+    _id: "1",
+    foo: "some fooish text",
+    bar: {
+      baz: 12
+    },
+    fooBar: {
+      _id: mediaRef.id,
+      _ref: "media",
+      _src: "https://barbar.baz/abc.pdf"
+    },
+    bazn: contentRef
+  },
+  type: "foo",
+  author: "bar",
+  date: "baz"
+};
+
+const _mediaRefs = {
+  [mediaRef.id]: mediaRef
+};
+
+const _contentRefs = {
+  [contentRef._content]: {
+    [contentRef._id]: {
+      someProps: "props"
+    } as any
+  }
+};
+
+const _refs = {
+  media: _mediaRefs,
+  content: _contentRefs
+};
+const singleContent: ContentWithRefs = {
+  ...data,
+  _refs
+};
+
+const listOfContent: ListChunkWithRefs<Content> = {
+  total: 1,
+  items: [data],
+  _refs
+};
+describe("pickFieldsFromResultData", () => {
+  describe("pick single content", () => {
+    it("should return full response", async () => {
+      await expect(
+        pickFieldsFromResultData(singleContent, [], model as Model)
+      ).toEqual(expect.objectContaining(singleContent));
+    });
+
+    it("should return only selected fields", async () => {
+      const { fooBar, bazn, ...restData } = data.data;
+      await expect(
+        pickFieldsFromResultData(
+          singleContent,
+          ["foo", "bar", "bazn"],
+          model as Model
+        )
+      ).toEqual(
+        expect.objectContaining({
+          ...singleContent,
+          data: { ...restData, bazn },
+          _refs: {
+            media: {},
+            content: _contentRefs
+          }
+        })
+      );
+      await expect(
+        pickFieldsFromResultData(singleContent, ["foo", "bar"], model as Model)
+      ).toEqual(
+        expect.objectContaining({
+          ...singleContent,
+          data: { ...restData },
+          _refs: {
+            media: {},
+            content: {}
+          }
+        })
+      );
+    });
+  });
+
+  describe("pick list of content", () => {
+    it("should return full response", async () => {
+      await expect(
+        pickFieldsFromResultData(listOfContent, [], model as Model)
+      ).toEqual(expect.objectContaining(listOfContent));
+    });
+
+    it("should return only selected fields", async () => {
+      const { fooBar, bazn, ...restData } = data.data;
+
+      await expect(
+        pickFieldsFromResultData(
+          listOfContent,
+          ["foo", "bar", "bazn"],
+          model as Model
+        )
+      ).toEqual(
+        expect.objectContaining({
+          total: 1,
+          items: [{ ...data, data: { ...restData, bazn } }],
+          _refs: {
+            media: {},
+            content: _contentRefs
+          }
+        })
+      );
+      await expect(
+        pickFieldsFromResultData(listOfContent, ["foo", "bar"], model as Model)
+      ).toEqual(
+        expect.objectContaining({
+          total: 1,
+          items: [{ ...data, data: { ...restData } }],
+          _refs: {
+            media: {},
+            content: {}
+          }
+        })
+      );
+    });
+  });
+});

--- a/src/content/rest/pickFieldsFromResultData.ts
+++ b/src/content/rest/pickFieldsFromResultData.ts
@@ -1,0 +1,84 @@
+import {
+  ContentWithRefs,
+  ListChunkWithRefs,
+  Content,
+  Model,
+  Refs
+} from "../../../typings";
+import _pick from "lodash/pick";
+import visit from "./visit";
+
+export default function pickFieldsFromResultData(
+  unpickedData: ContentWithRefs | ListChunkWithRefs<Content>,
+  fields: string[],
+  model: Model
+) {
+  if (!fields || !Array.isArray(fields) || !fields.length) return unpickedData;
+
+  const mediaToInclude: string[] = [];
+  const contentToInclude: any = {};
+
+  const pickNeededFields = (dataToPick: object) =>
+    _pick(dataToPick, [...fields, "_id"]);
+  const registerNeededRefs = (dataToWalk: object) =>
+    visit(dataToWalk, model, {
+      media: value => {
+        if (value) mediaToInclude.push(value._id);
+      },
+      content: value => {
+        if (value) {
+          if (!contentToInclude[value._content])
+            contentToInclude[value._content] = {};
+          contentToInclude[value._content][value._id] = {};
+        }
+      }
+    });
+
+  const pickNeededRefs = (refs: Refs) => {
+    const _refs: Refs = {
+      content: {},
+      media: {}
+    };
+
+    Object.keys(refs.media).forEach(key => {
+      if (mediaToInclude.includes(key)) _refs.media[key] = refs.media[key];
+    });
+    Object.keys(refs.content).forEach(key => {
+      if (contentToInclude[key]) {
+        _refs.content[key] = refs.content[key];
+      }
+    });
+    return _refs;
+  };
+
+  let pickedData: typeof unpickedData;
+
+  if ("items" in unpickedData) {
+    const pickedItems = unpickedData.items.map(item => {
+      const data = pickNeededFields(item.data);
+      registerNeededRefs(data);
+
+      return {
+        ...item,
+        data
+      };
+    });
+
+    pickedData = {
+      ...unpickedData,
+      items: pickedItems,
+      _refs: pickNeededRefs(unpickedData._refs)
+    };
+  } else {
+    const data = pickNeededFields(unpickedData.data);
+    registerNeededRefs(data);
+
+    pickedData = {
+      ...unpickedData,
+      data,
+      _refs: pickNeededRefs(unpickedData._refs)
+    };
+  }
+
+  return pickedData;
+}


### PR DESCRIPTION
Often a client only needs one or two fields from the data object. By allowing to specify top-level fields that get send back to the client, we prevent a lot of over-fetching.

This now can be done by adding the prop `fields` to the query with an array of field names.
If `fields` is not defined, the entire data object gets returned.