### PR TITLE
feat: add store flag for string fields

### DIFF
--- a/src/content/__tests__/indexNoStore.test.ts
+++ b/src/content/__tests__/indexNoStore.test.ts
@@ -1,0 +1,121 @@
+import { ModelOpts, Data } from "../../../typings";
+import faker from "faker";
+import { FsStorage, init, knexAdapter } from "../..";
+import LocalThumbnailProvider from "@cotype/local-thumbnail-provider";
+
+import request from "supertest";
+import tempy = require("tempy");
+import { Persistence } from "../../persistence";
+import fs from "fs-extra";
+
+import path from "path";
+import { login } from "../../__tests__/util";
+import {
+  createApiWriteHelpers,
+  createApiReadHelpers
+} from "../rest/__tests__/apiHelper";
+
+const uploadDir = path.join(__dirname, ".uploads");
+
+const dummyData: Data = {
+  title: faker.random.words(5),
+  indexButDontStore: faker.name.firstName()
+};
+
+const model: ModelOpts = {
+  name: "noStore",
+  fields: {
+    title: { type: "string" },
+    indexButDontStore: { type: "string", store: false }
+  }
+};
+
+const _refs = {
+  content: {},
+  media: {}
+};
+
+describe("Index fields but don't store them in revisions", () => {
+  let app: any;
+  let persistence: Persistence;
+  let server: request.SuperTest<request.Test>;
+  let headers: object;
+  let find: ReturnType<typeof createApiReadHelpers>["find"];
+  let search: ReturnType<typeof createApiReadHelpers>["search"];
+  let create: ReturnType<typeof createApiWriteHelpers>["create"];
+  let update: ReturnType<typeof createApiWriteHelpers>["update"];
+
+  beforeAll(async () => {
+    const storage = new FsStorage(uploadDir);
+
+    ({ app, persistence } = await init({
+      models: [model],
+      thumbnailProvider: new LocalThumbnailProvider(storage),
+      storage,
+      persistenceAdapter: knexAdapter({
+        client: "sqlite3",
+        connection: {
+          filename: tempy.file()
+        },
+        useNullAsDefault: true
+      })
+    }));
+
+    ({ server, headers } = await login(
+      request(app),
+      "admin@cotype.dev",
+      "admin"
+    ));
+
+    ({ create, update } = createApiWriteHelpers(server, headers));
+    ({ find, search } = createApiReadHelpers(server));
+  });
+
+  afterAll(async () => {
+    await fs.remove(uploadDir);
+    return persistence.shutdown();
+  });
+
+  it("should not store flagged fields", async () => {
+    const data = await create("noStore", dummyData);
+    expect(data).toStrictEqual({
+      id: data.id,
+      data: { title: dummyData.title }
+    });
+
+    const updatedData = await update("noStore", data.id, dummyData);
+    expect(updatedData).toStrictEqual({
+      id: data.id,
+      data: { title: dummyData.title }
+    });
+
+    const foundData = await find("noStore", data.id, {}, false);
+    expect(foundData).toStrictEqual({
+      title: dummyData.title,
+      _id: data.id,
+      _refs
+    });
+  });
+
+  it("should index flagged fields", async () => {
+    const foundData = await search(dummyData.indexButDontStore, {
+      linkableOnly: false,
+      published: false
+    });
+
+    expect(foundData).toStrictEqual({
+      total: 1,
+      items: [
+        {
+          title: dummyData.title,
+          id: expect.any(Number),
+          image: {
+            _ref: "media",
+            _src: null
+          }
+        }
+      ],
+      _refs
+    });
+  });
+});

--- a/src/content/rest/__tests__/apiHelper.ts
+++ b/src/content/rest/__tests__/apiHelper.ts
@@ -1,0 +1,149 @@
+import { stringify } from "qs";
+import request from "supertest";
+
+export function createApiReadHelpers(server: request.SuperTest<request.Test>) {
+  const list = async (
+    type: string,
+    params: object = {},
+    published: boolean = true
+  ) => {
+    const { body } = await server
+      .get(
+        `/rest/${published ? "published" : "drafts"}/${type}?${stringify(
+          params
+        )}`
+      )
+      .expect(200);
+
+    return body;
+  };
+  const find = async (
+    type: string,
+    id: string,
+    params: object = {},
+    published: boolean = true
+  ) => {
+    const { body } = await server
+      .get(
+        `/rest/${published ? "published" : "drafts"}/${type}/${id}?${stringify(
+          params
+        )}`
+      )
+      .expect(200);
+
+    return body;
+  };
+
+  const search = async (
+    term: string,
+    opts: {
+      published?: boolean;
+      linkableOnly?: boolean;
+      includeModels?: string[];
+      excludeModels?: string[];
+      limit?: number;
+      offset?: number;
+    }
+  ) => {
+    const {
+      published = true,
+      linkableOnly = true,
+      includeModels = [],
+      excludeModels = [],
+      limit = 50,
+      offset = 0
+    } = opts;
+    const { body } = await server
+      .get(
+        `/rest/${published ? "published" : "drafts"}/search/content?${stringify(
+          {
+            term,
+            limit,
+            offset,
+            linkableOnly,
+            includeModels,
+            excludeModels
+          }
+        )}`
+      )
+      .expect(200);
+
+    return body;
+  };
+
+  const suggest = async (
+    term: string,
+    opts: {
+      published?: boolean;
+      linkableOnly?: boolean;
+      includeModels?: string[];
+      excludeModels?: string[];
+    }
+  ) => {
+    const {
+      published = true,
+      linkableOnly = true,
+      includeModels = [],
+      excludeModels = []
+    } = opts;
+    const { body } = await server
+      .get(
+        `/rest/${published ? "published" : "drafts"}/search/suggest?${stringify(
+          {
+            term,
+            linkableOnly,
+            includeModels,
+            excludeModels
+          }
+        )}`
+      )
+      .expect(200);
+
+    return body;
+  };
+
+  const findByField = async (
+    type: string,
+    field: string,
+    value: string,
+    params: object = {},
+    published: boolean = true
+  ) => {
+    const { body } = await server
+      .get(
+        `/rest/${
+          published ? "published" : "drafts"
+        }/${type}/${field}/${value}?${stringify(params)}`
+      )
+      .expect(200);
+
+    return body;
+  };
+
+  return { find, list, search, findByField, suggest };
+}
+export function createApiWriteHelpers(
+  server: request.SuperTest<request.Test>,
+  headers: object
+) {
+  const create = async (type: string, data: object) => {
+    const { body } = await server
+      .post(`/admin/rest/content/${type}`)
+      .set(headers)
+      .send({ data })
+      .expect(200);
+
+    return body;
+  };
+
+  const update = async (type: string, id: string, data: object) => {
+    const { body } = await server
+      .put(`/admin/rest/content/${type}/${id}`)
+      .set(headers)
+      .send(data)
+      .expect(200);
+
+    return body;
+  };
+  return { create, update };
+}

--- a/src/content/rest/filterRefData.ts
+++ b/src/content/rest/filterRefData.ts
@@ -26,8 +26,7 @@ export const getDeepJoins = (
             (topField.item.type === "content" ||
               topField.item.type === "references"))
         ) {
-          const searchModels = (("models" in topField &&
-            topField.models) ||
+          const searchModels = (("models" in topField && topField.models) ||
             ("model" in topField && [topField.model]) ||
             (topField.type === "list" &&
               "models" in topField.item &&
@@ -98,7 +97,7 @@ export const filterContentData = (
 ) => {
   return {
     ...pick(content.data, join[content.type.toLowerCase()]),
-    _id: content.id,
+    _id: String(content.id),
     _type: content.type
   };
 };

--- a/src/model/visit.ts
+++ b/src/model/visit.ts
@@ -4,6 +4,8 @@ import * as Cotype from "../../typings";
  */
 import _ from "lodash";
 
+export const NO_STORE_VALUE = "$$__noStore__$$";
+
 type Visitor = {
   [key: string]: (
     value: any,
@@ -73,10 +75,15 @@ export default function visit(
             _.set(parent, key, undefined);
           }
         },
-        Array.isArray(parent) ? stringPath.slice(0,-1) : stringPath + key // Remove Dot and ArrayKey when Parent is List
+        Array.isArray(parent) ? stringPath.slice(0, -1) : stringPath + key // Remove Dot and ArrayKey when Parent is List
       );
       if (typeof ret !== "undefined") {
-        if (parent && key) _.set(parent, key, ret);
+        if (parent && key) {
+          if (typeof ret === "string" && ret === NO_STORE_VALUE) {
+            return _.set(parent, key, undefined);
+          }
+          _.set(parent, key, ret);
+        }
       }
     }
   };

--- a/src/persistence/ContentPersistence.ts
+++ b/src/persistence/ContentPersistence.ts
@@ -6,6 +6,7 @@ import * as Cotype from "../../typings";
 import _escapeRegExp from "lodash/escapeRegExp";
 import _flatten from "lodash/flatten";
 import _uniq from "lodash/uniq";
+import _cloneDeep from "lodash/cloneDeep";
 import { ContentAdapter } from "./adapter";
 import removeDeprecatedData from "./removeDeprecatedData";
 import ReferenceConflictError from "./errors/ReferenceConflictError";
@@ -18,6 +19,8 @@ import { ContentFormat } from "../../typings";
 import extractMatch from "../model/extractMatch";
 import extractText from "../model/extractText";
 import log from "../log";
+import visit, { NO_STORE_VALUE } from "../model/visit";
+import setPosition from "../model/setPosition";
 
 function findValueByPath(path: string | undefined, data: Cotype.Data) {
   if (!path) return;
@@ -63,23 +66,22 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
   async applyPreHooks<T>(
     event: keyof Cotype.PreHooks,
     model: Cotype.Model,
-    data: Cotype.Data,
-    action: (d: Cotype.Data) => Promise<T>
-  ): Promise<[T, Cotype.Data]> {
+    data: Cotype.Data
+  ): Promise<Cotype.Data> {
     if (!this.config.contentHooks || !this.config.contentHooks.preHooks)
-      return Promise.all([action(data), data]);
+      return data;
     const preHook = this.config.contentHooks.preHooks[event];
-    if (!preHook) return Promise.all([action(data), data]);
+    if (!preHook) return data;
 
     try {
       const hookData = await preHook(model, data);
-      return Promise.all([action(hookData), hookData]);
+      return hookData;
     } catch (error) {
       log.error(
         `💥  An error occurred in the content preHook "${event}" for a "${model.name}" content`
       );
       log.error(error);
-      return Promise.all([action(data), data]);
+      return data;
     }
   }
 
@@ -162,18 +164,23 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
     data: Cotype.Data,
     models: Cotype.Model[]
   ) {
-    // NOTE: principal.id will always be set since anonymous access is prevented by ACL.
+    data = this.setOrderPosition(data, model, models);
+    const hookData = await this.applyPreHooks("onCreate", model, data);
 
-    const [id, hookData] = await this.applyPreHooks(
-      "onCreate",
+    const { storeData, indexData } = await this.prepareData(hookData, model);
+
+    // NOTE: principal.id will always be set since anonymous access is prevented by ACL.
+    const id = await this.adapter.create(
+      storeData,
+      indexData,
       model,
-      data,
-      (d: Cotype.Data) => this.adapter.create(model, d, principal.id!, models)
+      models,
+      principal.id!
     );
 
-    this.applyPostHooks("onCreate", model, { id, data: hookData });
+    this.applyPostHooks("onCreate", model, { id, data: storeData });
 
-    return { id, data: hookData };
+    return { id: String(id), data: storeData };
   }
 
   async createRevision(
@@ -183,8 +190,18 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
     data: object,
     models: Cotype.Model[]
   ) {
+    const { storeData, indexData } = await this.prepareData(data, model);
     // NOTE: principal.id will always be set since anonymous access is prevented by ACL.
-    return this.adapter.createRevision(model, id, principal.id!, data, models);
+    const rev = await this.adapter.createRevision(
+      storeData,
+      indexData,
+      model,
+      models,
+      id,
+      principal.id!
+    );
+
+    return { rev, data: storeData };
   }
 
   async fetchRefs(
@@ -332,12 +349,18 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
     data: object,
     models: Cotype.Model[]
   ): Promise<{ id: string; data: object }> {
-    const hookResp = await this.applyPreHooks("onSave", model, data, d =>
-      this.createRevision(principal, model, id, d, models)
-    );
-    const resp = {
+    const hookData = await this.applyPreHooks("onSave", model, data);
+    const rev = await this.createRevision(
+      principal,
+      model,
       id,
-      data: hookResp[1]
+      hookData,
+      models
+    );
+
+    const resp = {
+      id: String(id),
+      data: rev.data
     };
 
     this.applyPostHooks("onSave", model, resp);
@@ -556,5 +579,42 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
       }
     });
     return terms.sort((a, b) => a.length - b.length || a.localeCompare(b));
+  }
+
+  private async setOrderPosition(
+    data: Cotype.Data,
+    model: Cotype.Model,
+    models: Cotype.Model[]
+  ) {
+    if (model.orderBy) {
+      const lastItem = await this.adapter.list(model, models, {
+        limit: 1,
+        orderBy: model.orderBy,
+        order: "desc",
+        offset: 0
+      });
+
+      const orderPath = model.orderBy.split(".");
+
+      const lastOrderValue = (orderPath.reduce(
+        (obj, key) => (obj && obj[key] !== "undefined" ? obj[key] : undefined),
+        lastItem.total > 0 ? lastItem.items[0].data : {}
+      ) as unknown) as string;
+
+      data = setPosition(data, model, lastOrderValue);
+    }
+    return data;
+  }
+
+  private prepareData(data: Cotype.Data, model: Cotype.Model) {
+    const storeData = _cloneDeep(data);
+
+    visit(storeData, model, {
+      string: (_, field: Cotype.Text) => {
+        if (field.store === false) return NO_STORE_VALUE;
+      }
+    });
+
+    return { storeData, indexData: data };
   }
 }

--- a/src/persistence/adapter/__tests__/index.test.ts
+++ b/src/persistence/adapter/__tests__/index.test.ts
@@ -142,8 +142,9 @@ describe.each(implementations)("%s adapter", (_, impl) => {
         password: "xxx"
       });
 
+      const data = { title: "News" };
       // create content with user for a foreign key constraint
-      await content.create(news, { title: "News" }, id, models.content);
+      await content.create(data, data, news, models.content, id);
 
       await settings.deleteUser(id);
       const userList = await settings.list(users, {});
@@ -187,10 +188,11 @@ describe.each(implementations)("%s adapter", (_, impl) => {
         data.map(
           d =>
             content.create(
-              news,
               { ...sampleNews, ...d },
-              author,
-              models.content
+              { ...sampleNews, ...d },
+              news,
+              models.content,
+              author
             ) as Promise<string>
         )
       );
@@ -205,10 +207,11 @@ describe.each(implementations)("%s adapter", (_, impl) => {
         data.map(
           d =>
             content.create(
-              pages,
               { ...samplePage, ...d },
-              author,
-              models.content
+              { ...samplePage, ...d },
+              pages,
+              models.content,
+              author
             ) as Promise<string>
         )
       );
@@ -219,10 +222,11 @@ describe.each(implementations)("%s adapter", (_, impl) => {
         data.map(
           d =>
             content.create(
-              indexContent,
               { ...d },
-              author,
-              models.content
+              { ...d },
+              indexContent,
+              models.content,
+              author
             ) as Promise<string>
         )
       );
@@ -245,15 +249,17 @@ describe.each(implementations)("%s adapter", (_, impl) => {
 
     it("should create a revision", async () => {
       const [id] = await createNews({});
+      const data = {
+        ...sampleNews,
+        title: "Updated"
+      };
       const rev = await content.createRevision(
+        data,
+        data,
         news,
+        models.content,
         id,
-        author,
-        {
-          ...sampleNews,
-          title: "Updated"
-        },
-        models.content
+        author
       );
       await expect(rev).toBeGreaterThan(0);
     });
@@ -280,15 +286,17 @@ describe.each(implementations)("%s adapter", (_, impl) => {
 
     it("should list versions", async () => {
       const [id] = await createNews({});
+      const data = {
+        ...sampleNews,
+        title: "Updated"
+      };
       await content.createRevision(
+        data,
+        data,
         news,
+        models.content,
         id,
-        author,
-        {
-          ...sampleNews,
-          title: "Updated"
-        },
-        models.content
+        author
       );
       const revs = await content.listVersions(news, id);
       await expect(revs).toMatchObject([
@@ -877,28 +885,33 @@ describe.each(implementations)("%s adapter", (_, impl) => {
           }
         );
 
+        const data1 = {
+          ...sampleNews,
+          title: "Lorem ipsum dolor"
+        };
+
         // Create a second revision...
         const rev = await content.createRevision(
+          data1,
+          data1,
           news,
+          models.content,
           ids[0],
-          author,
-          {
-            ...sampleNews,
-            title: "Lorem ipsum dolor"
-          },
-          models.content
+          author
         );
 
+        const data2 = {
+          ...sampleNews,
+          title: "Lorem ipsum"
+        };
         // ...and a third one
         await content.createRevision(
+          data2,
+          data2,
           news,
+          models.content,
           ids[0],
-          author,
-          {
-            ...sampleNews,
-            title: "Lorem ipsum"
-          },
-          models.content
+          author
         );
 
         // ...and publish it
@@ -992,16 +1005,19 @@ describe.each(implementations)("%s adapter", (_, impl) => {
           items: [{ id: pageIds[0] }]
         });
 
+        const data3 = {
+          ...sampleNews,
+          title: "Don't find me"
+        };
+
         // Update previously found content
         await content.createRevision(
+          data3,
+          data3,
           news,
+          models.content,
           ids[1],
-          author,
-          {
-            ...sampleNews,
-            title: "Don't find me"
-          },
-          models.content
+          author
         );
 
         await expect(
@@ -1064,39 +1080,43 @@ describe.each(implementations)("%s adapter", (_, impl) => {
     describe("Content with unique fields", () => {
       it("should create content", async () => {
         const id = await content.create(
-          uniqueContent,
           { slug: "unique" },
-          author,
-          models.content
+          { slug: "unique" },
+          uniqueContent,
+          models.content,
+          author
         );
         await expect(id).toBeGreaterThan(0);
       });
       it("should not create content", async () => {
         await expect(
           content.create(
-            uniqueContent,
             { slug: "unique" },
-            author,
-            models.content
+            { slug: "unique" },
+            uniqueContent,
+            models.content,
+            author
           )
         ).rejects.toBeInstanceOf(UniqueFieldError);
       });
 
       it("should be able to update content", async () => {
         const id = await content.create(
-          uniqueContent,
           { slug: "foo-bar-baz" },
-          author,
-          models.content
+          { slug: "foo-bar-baz" },
+          uniqueContent,
+          models.content,
+          author
         );
 
         await expect(
           await content.createRevision(
-            uniqueContent,
-            id,
-            author,
             { slug: "foo-bar-baz" },
-            models.content
+            { slug: "foo-bar-baz" },
+            uniqueContent,
+            models.content,
+            id,
+            author
           )
         ).not.toBeNaN();
       });
@@ -1379,10 +1399,11 @@ describe.each(implementations)("%s adapter", (_, impl) => {
 
     it("should not delete media in use", async () => {
       const id = (await content.create(
-        news,
         { title: "News", image: image1.id },
-        author,
-        models.content
+        { title: "News", image: image1.id },
+        news,
+        models.content,
+        author
       )) as string;
 
       await expect(
@@ -1391,50 +1412,59 @@ describe.each(implementations)("%s adapter", (_, impl) => {
 
       await content.setPublishedRev(news, id, 1, models.content);
 
+      const data = {
+        title: "News Rev 2",
+        image: null
+      };
+
       await content.createRevision(
+        data,
+        data,
         news,
+        models.content,
         id,
-        author,
-        {
-          title: "News Rev 2",
-          image: null
-        },
-        models.content
+        author
       );
 
       await expect(
         media.delete(image1.id, models.content)
       ).rejects.toBeInstanceOf(ReferenceConflictError);
 
+      const data2 = { title: "News", image: image3.id };
       const id2 = (await content.create(
+        data2,
+        data2,
         news,
-        { title: "News", image: image3.id },
-        author,
-        models.content
+        models.content,
+        author
       )) as string;
 
+      const data3 = {
+        title: "News Rev 2",
+        image: image3.id
+      };
       await content.createRevision(
+        data3,
+        data3,
         news,
+        models.content,
         id2,
-        author,
-        {
-          title: "News Rev 2",
-          image: image3.id
-        },
-        models.content
+        author
       );
 
       await content.setPublishedRev(news, id2, 2, models.content);
 
+      const data4 = {
+        title: "News Rev 3",
+        image: image3.id
+      };
       await content.createRevision(
+        data4,
+        data4,
         news,
+        models.content,
         id2,
-        author,
-        {
-          title: "News Rev 3",
-          image: image3.id
-        },
-        models.content
+        author
       );
 
       await expect(
@@ -1456,10 +1486,11 @@ describe.each(implementations)("%s adapter", (_, impl) => {
       await media.create(image);
 
       const id = (await content.create(
-        news,
         { title: "News", image: image.id },
-        author,
-        models.content
+        { title: "News", image: image.id },
+        news,
+        models.content,
+        author
       )) as string;
 
       await content.delete(news, id);
@@ -1481,10 +1512,11 @@ describe.each(implementations)("%s adapter", (_, impl) => {
       await media.create(image);
 
       await content.create(
-        news,
         { title: "News", image: image.id },
-        author,
-        models.content
+        { title: "News", image: image.id },
+        news,
+        models.content,
+        author
       );
 
       await expect(

--- a/src/persistence/adapter/index.ts
+++ b/src/persistence/adapter/index.ts
@@ -21,17 +21,19 @@ export type SettingsAdapter = {
 
 export type ContentAdapter = {
   create(
+    storeData: Cotype.Data,
+    indexData: Cotype.Data,
     model: Cotype.Model,
-    data: object,
-    author: string,
-    models: Cotype.Model[]
+    models: Cotype.Model[],
+    author: string
   ): Promise<string>;
   createRevision(
+    storeData: Cotype.Data,
+    indexData: Cotype.Data,
     model: Cotype.Model,
+    models: Cotype.Model[],
     id: string,
-    author: string,
-    data: object,
-    models: Cotype.Model[]
+    author: string
   ): Promise<number>;
   findByMedia(media: string): Promise<any[]>;
   list(

--- a/typings/entities.d.ts
+++ b/typings/entities.d.ts
@@ -164,6 +164,11 @@ export type Record = {
   _id: string;
 } & Data;
 
+export type RevisionRecord = {
+  rev: number;
+  data: Data;
+};
+
 export type Content = DataRecord & {
   type: string;
   author: string;
@@ -263,17 +268,17 @@ export type WritableDataSource = ReadOnlyDataSource & {
   create(
     principal: Principal,
     model: Model,
-    data: object,
+    data: Data,
     models: Model[]
-  ): Promise<{ id: string; data: object }>;
+  ): Promise<{ id: string; data: Data }>;
   delete(principal: Principal, model: Model, id: string): Promise<void>;
   update(
     principal: Principal,
     model: Model,
     id: string,
-    data: object,
+    data: Data,
     models: Model[]
-  ): Promise<{ id: string; data: object }>;
+  ): Promise<{ id: string; data: Data }>;
 };
 
 export type VersionedDataSource = WritableDataSource & {
@@ -299,9 +304,9 @@ export type VersionedDataSource = WritableDataSource & {
     principal: Principal,
     model: Model,
     id: string,
-    data: object,
+    data: Data,
     models: Model[]
-  ): Promise<number>;
+  ): Promise<RevisionRecord>;
   schedule(
     principal: Principal,
     model: Model,

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -40,6 +40,7 @@ type Text = {
   hidden?: boolean;
   validationRegex?: string;
   regexError?: string;
+  store?: boolean;
 };
 type TextArea = {
   type: "string";
@@ -53,6 +54,7 @@ type TextArea = {
   index?: boolean;
   search?: boolean;
   hidden?: boolean;
+  store?: boolean;
 };
 
 type Slug = {


### PR DESCRIPTION
Add `store` prop to string fields in order to exclude those fields from revisions. 
This is useful for autogenerated content with the sole purpose of adding keywords for search.

<!-- semantish-prerelease -->
<hr /><p><time>(7/30/2019, 2:31:10 PM)</date> Pre-released as <code>@cotype/core@1.22.0-beta.d238bc6</code></p>
<!-- /semantish-prerelease -->