### PR TITLE
feat(client + server): add dashboard to see recent changes at a glance

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,6 +26,7 @@ import Login from "./auth/Login";
 import UserContext from "./auth/UserContext";
 import IconGallery from "./IconGallery";
 import List from "./List";
+import Dashboard from "./Dashboard";
 import SplitPane from "./common/SplitPane";
 import ErrorBoundary from "./ErrorBoundary";
 
@@ -100,6 +101,10 @@ class App extends React.Component<{}, State> {
                   <ErrorBoundary>
                     <Main>
                       <Switch>
+                        <Route
+                          path={`${basePath}/dashboard`}
+                          render={props => <Dashboard />}
+                        />
                         {navigation.map(item => (
                           <Route
                             key={item.path}
@@ -161,11 +166,7 @@ class App extends React.Component<{}, State> {
                           component={IconGallery}
                         />
                         <Route exact path={basePath}>
-                          <Redirect
-                            to={`${basePath}${
-                              navigation[0] ? navigation[0].path! : "/media"
-                            }`}
-                          />
+                          <Redirect to={`${basePath}/dashboard`} />
                         </Route>
                       </Switch>
                     </Main>

--- a/client/src/Dashboard/Header.tsx
+++ b/client/src/Dashboard/Header.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components/macro";
+
+const Header = styled("div")`
+  background: white;
+  color: var(--dark-color);
+  width: 100%;
+  padding: 12px 16px;
+  margin: 0;
+  box-sizing: border-box;
+  font-weight: 500;
+  display: flex;
+  justify-content: space-between;
+  box-shadow: 0px 2px 10px -3px rgba(0, 0, 0, 0.1);
+  margin-bottom: 4px;
+`;
+export default Header;

--- a/client/src/Dashboard/Item.tsx
+++ b/client/src/Dashboard/Item.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components/macro";
+
+const Item = styled("div")`
+  cursor: pointer;
+  padding: 12px 16px;
+  box-sizing: border-box;
+  border-bottom: 1px solid #f5f5f5;
+  :hover {
+    background-color: var(--light-color);
+  }
+`;
+
+export default Item;

--- a/client/src/Dashboard/ItemList.tsx
+++ b/client/src/Dashboard/ItemList.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import Item from "./Item";
+import ScrollList, { RenderInfo } from "../common/ScrollList";
+import ResultItem from "../common/ResultItem";
+import { SearchResultItem } from "../../../typings";
+import NothingFound from "./NothingFound";
+
+const LIMIT = 50;
+
+type Result = {
+  total: number;
+  items: SearchResultItem[];
+};
+
+type Props = {
+  fetchItems: (offset: number, limit: number) => Promise<Result>;
+  noResultText?: string;
+};
+export default function ItemList({ fetchItems, noResultText }: Props) {
+  const [offset, setOffset] = useState(0);
+  const [items, setItems] = useState<null | Result>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    const fetchData = async () => {
+      const fetchedItems = await fetchItems(offset, LIMIT);
+      const { items: i, total: t } = fetchedItems;
+      if (!canceled) {
+        setItems({ total: t, items: items ? items.items.concat(i) : i });
+      }
+    };
+    fetchData();
+
+    return () => {
+      canceled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [offset]);
+
+  const onRowsRendered = ({ overscanStopIndex }: RenderInfo) => {
+    // Lazy-load next batch of items
+    if (overscanStopIndex >= offset + LIMIT) setOffset(offset + LIMIT);
+  };
+
+  if (!items) return null;
+
+  const { total, items: entries } = items;
+  return total > 0 ? (
+    <ScrollList
+      rowCount={total || 0}
+      items={entries}
+      visibleRows={8}
+      onRowsRendered={onRowsRendered}
+      renderRow={({ key, index, style }) => {
+        const item = entries[index];
+        if (!item) return <div style={style} />;
+        return (
+          <Item style={style}>
+            <ResultItem key={`${key}-${item.id}`} item={item} />
+          </Item>
+        );
+      }}
+    />
+  ) : (
+    <NothingFound text={noResultText || ""}></NothingFound>
+  );
+}

--- a/client/src/Dashboard/NothingFound.tsx
+++ b/client/src/Dashboard/NothingFound.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components/macro";
+
+const Container = styled("div")`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  text-align: center;
+`;
+type Props = {
+  text: string;
+};
+export default function NothingFound({ text }: Props) {
+  return (
+    <Container>
+      <span>{text}</span>
+    </Container>
+  );
+}

--- a/client/src/Dashboard/UnpublishedContent.tsx
+++ b/client/src/Dashboard/UnpublishedContent.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "./Header";
+import ItemList from "./ItemList";
+import api from "../api";
+
+export default function UnpublishedContent() {
+  return (
+    <>
+      <Header>Unpublished changes</Header>
+      <ItemList
+        fetchItems={() => api.get("/dashboard/unpublished")}
+        noResultText="There are no unpublished changes"
+      ></ItemList>
+    </>
+  );
+}

--- a/client/src/Dashboard/UpdatedContent.tsx
+++ b/client/src/Dashboard/UpdatedContent.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import styled from "styled-components/macro";
+import Header from "./Header";
+import api from "../api";
+import ItemList from "./ItemList";
+import ToggleSwitch from "../common/ToggleSwitch";
+
+const Filter = styled("div")`
+  display: inline-flex;
+  justify-content: center;
+  & > span {
+    margin-right: 4px;
+  }
+`;
+
+export default function UpdatedContent() {
+  const [byUser, setByUser] = useState(false);
+
+  return (
+    <>
+      <Header>
+        <span>Recently updated</span>
+        <Filter>
+          <span>By me</span>
+          <ToggleSwitch on={byUser} onClick={() => setByUser(!byUser)} />
+        </Filter>
+      </Header>
+      <ItemList
+        key={byUser ? 0 : 1}
+        fetchItems={() =>
+          api.get(`/dashboard/${byUser ? "updated-by-user" : "updated"}`)
+        }
+        noResultText="There is no updated content"
+      />
+    </>
+  );
+}

--- a/client/src/Dashboard/index.tsx
+++ b/client/src/Dashboard/index.tsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components/macro";
+import UnpublishedContent from "./UnpublishedContent";
+import UpdatedContent from "./UpdatedContent";
+import api from "../api";
+
+const Container = styled("div")`
+  padding: 36px;
+  width: 100%;
+`;
+const Flex = styled("div")`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  & > div:not(:last-child) {
+    margin-right: 48px;
+  }
+  @media screen and (max-width: 786px) {
+    flex-direction: column;
+    & > div:not(:last-child) {
+      margin-right: 0;
+      margin-bottom: 48px;
+    }
+  }
+`;
+
+const Title = styled("h1")`
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 36px;
+  font-weight: 200;
+`;
+const Column = styled("div")`
+  flex: 1;
+  background: white;
+  border-radius: 3px;
+  overflow: hidden;
+  max-width: 450px;
+  box-shadow: 0px 2px 10px -3px rgba(0, 0, 0, 0.1);
+  min-height: 515px;
+  position: relative;
+  @media screen and (max-width: 786px) {
+    max-width: 100%;
+  }
+`;
+
+export default function Dashboard() {
+  const [totalCount, setTotalCount] = useState<null | {
+    totalByUser: number;
+    total: number;
+  }>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    const fetchData = async () => {
+      const [{ total }, { total: totalByUser }] = await Promise.all([
+        api.get("/dashboard/updated?limit=0"),
+        api.get("/dashboard/updated-by-user?limit=0")
+      ]);
+      if (!canceled) setTotalCount({ total, totalByUser });
+    };
+    fetchData();
+
+    return () => {
+      canceled = true;
+    };
+  }, []);
+  return (
+    <Container>
+      {totalCount && (
+        <Title>
+          There exist <b>{totalCount.total.toLocaleString()}</b> contents and
+          you already worked on <b>{totalCount.totalByUser.toLocaleString()}</b>{" "}
+          of them
+        </Title>
+      )}
+      <Flex>
+        <Column>
+          <UnpublishedContent />
+        </Column>
+        <Column>
+          <UpdatedContent />
+        </Column>
+      </Flex>
+    </Container>
+  );
+}

--- a/client/src/Header/index.tsx
+++ b/client/src/Header/index.tsx
@@ -64,6 +64,12 @@ class Header extends Component<Props> {
     return (
       <Bar>
         <Items>
+          <ItemLink
+            {...testable("main-navigation-item")}
+            to={`${basePath}/dashboard`}
+          >
+            Dashboard
+          </ItemLink>
           {navigation.map(({ path, name }) => (
             <ItemLink
               {...testable("main-navigation-item")}

--- a/client/src/common/ResultItem.tsx
+++ b/client/src/common/ResultItem.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import _escape from "lodash/escape";
 import basePath from "../basePath";
 import ImageCircle from "../common/ImageCircle";
-
+import TimeAgo from "react-time-ago";
 import ColorHash from "color-hash";
 import { withModelPaths } from "../ModelPathsContext";
 const colorHash = new ColorHash({ saturation: 0.7, lightness: 0.6 });
@@ -56,6 +56,17 @@ const Kind = styled("div")`
   flex-shrink: 0;
 `;
 
+const ChangedBy = styled("span")`
+  color: var(--dark-grey);
+  font-size: 0.8em;
+`;
+
+const LastChangedBy = ({ author, date }: { author: string; date: string }) => (
+  <ChangedBy>
+    Updated by {author} <TimeAgo date={new Date(date)} />
+  </ChangedBy>
+);
+
 export const ResultTitle = ({
   title,
   term
@@ -105,6 +116,7 @@ export const BasicResultItem = ({ item, term }: BasicProps) => {
       <Wrapper>
         <TitleWrapper>
           <ResultTitle title={title} term={term}></ResultTitle>
+
           <Kind style={{ background: colorHash.hex(kind) }}>{kind}</Kind>
         </TitleWrapper>
         <DescriptionWrapper>
@@ -114,6 +126,9 @@ export const BasicResultItem = ({ item, term }: BasicProps) => {
             </Description>
           )}
         </DescriptionWrapper>
+        {"author_name" in item && "date" in item && (
+          <LastChangedBy date={item.date} author={item.author_name} />
+        )}
       </Wrapper>
     </ImageItem>
   );

--- a/cypress/integration/accessControl.spec.ts
+++ b/cypress/integration/accessControl.spec.ts
@@ -32,6 +32,7 @@ context("Access Control", () => {
 
   describe("for view", () => {
     it("does not show edit buttons", () => {
+      frame.navigation("Content").click();
       frame.sidebarItem("Bars").click();
       content.addButton().should("have.length", 0);
       content.listItem("Test Bar").click();
@@ -49,6 +50,7 @@ context("Access Control", () => {
 
   describe("for edit", () => {
     it("allows content creation", () => {
+      frame.navigation("Content").click();
       cy.withContext(({ bazName }) => {
         frame.sidebarItem("Bazs").click();
         content.add();
@@ -81,6 +83,7 @@ context("Access Control", () => {
 
     it("allows content deletion", () => {
       cy.withContext(({ bazName }) => {
+        frame.navigation("Content").click();
         frame.sidebarItem("Bazs").click();
         content.listItem(bazName).click();
         content.delete();
@@ -98,6 +101,7 @@ context("Access Control", () => {
 
   describe("for publish", () => {
     it("allows content publishing", () => {
+      frame.navigation("Content").click();
       frame.sidebarItem("Quxes").click();
       content.listItem("Test Qux").click();
       // Assert it's published

--- a/cypress/integration/settings.spec.ts
+++ b/cypress/integration/settings.spec.ts
@@ -59,6 +59,7 @@ context("Settings", () => {
     cy.withContext(({ userEmail, password, userName }) => {
       cy.login({ email: userEmail, password, name: userName });
       frame.navigation("Settings").should("not.exist");
+      frame.navigation("Content").click();
       frame.sidebarItems().should("have.length", 1);
       frame.sidebarItem("Foos").should("have.length", 1);
     });

--- a/src/__tests__/dashboard.test.ts
+++ b/src/__tests__/dashboard.test.ts
@@ -1,0 +1,150 @@
+import path from "path";
+import tempy from "tempy";
+import fs from "fs-extra";
+import request, { SuperTest, Test } from "supertest";
+import { init, Persistence, knexAdapter } from "..";
+import models from "./models";
+import { login, withTempRole } from "./util";
+import { Permission } from "../auth/acl";
+import FsStorage from "../media/storage/FsStorage";
+import LocalThumbnailProvider from "@cotype/local-thumbnail-provider";
+import { createApiWriteHelpers } from "../content/rest/__tests__/apiHelper";
+
+const { view, edit, publish } = Permission;
+
+const uploadDir = path.join(__dirname, ".uploads");
+
+const itemShape = {
+  author_name: expect.any(String),
+  date: expect.any(String),
+  id: expect.any(Number),
+  kind: expect.any(String),
+  model: expect.any(String),
+  orderValue: expect.any(String),
+  title: expect.any(String),
+  type: expect.any(String)
+};
+
+describe("dashboard api", () => {
+  let app: any;
+  let persistence: Persistence;
+
+  beforeAll(async () => {
+    const storage = new FsStorage(uploadDir);
+
+    ({ app, persistence } = await init({
+      models,
+      storage,
+      thumbnailProvider: new LocalThumbnailProvider(storage),
+      persistenceAdapter: knexAdapter({
+        client: "sqlite3",
+        connection: {
+          filename: tempy.file()
+        },
+        useNullAsDefault: true
+      })
+    }));
+  });
+
+  afterAll(async () => {
+    await fs.remove(uploadDir);
+    return persistence.shutdown();
+  });
+
+  describe("dashboard", () => {
+    let headersAdmin: object;
+    let server: SuperTest<Test>;
+    let headersLimited: object;
+    let serverLimited: SuperTest<Test>;
+
+    beforeAll(async () => {
+      ({ headers: headersLimited, server: serverLimited } = await withTempRole(
+        request(app),
+        {
+          settings: false,
+          content: {
+            pages: view | edit | publish // tslint:disable-line:no-bitwise
+          }
+        }
+      ));
+
+      let { create } = createApiWriteHelpers(serverLimited, headersLimited);
+
+      await create("pages", { title: "Foo" });
+
+      ({ server, headers: headersAdmin } = await login(
+        request(app),
+        "admin@cotype.dev",
+        "admin"
+      ));
+
+      ({ create } = createApiWriteHelpers(server, headersAdmin));
+      await create("products", { title: "Bar" });
+    });
+
+    it("provides dashboard data", async () => {
+      const { body: unpublished } = await server
+        .get("/admin/rest/dashboard/unpublished")
+        .set(headersAdmin)
+        .expect(200);
+      expect(unpublished).toStrictEqual({
+        total: 2,
+        items: [
+          expect.objectContaining(itemShape),
+          expect.objectContaining(itemShape)
+        ]
+      });
+
+      const { body: updated } = await server
+        .get("/admin/rest/dashboard/updated")
+        .set(headersAdmin)
+        .expect(200);
+      expect(updated).toStrictEqual({
+        total: 2,
+        items: [
+          expect.objectContaining(itemShape),
+          expect.objectContaining(itemShape)
+        ]
+      });
+
+      const { body: updatedByMe } = await server
+        .get("/admin/rest/dashboard/updated-by-user")
+        .set(headersAdmin)
+        .expect(200);
+
+      expect(updatedByMe).toStrictEqual({
+        total: 1,
+        items: [expect.objectContaining(itemShape)]
+      });
+    });
+    it("provides limited dashboard data with limited access rights", async () => {
+      const { body: unpublished } = await serverLimited
+        .get("/admin/rest/dashboard/unpublished")
+        .set(headersLimited)
+        .expect(200);
+      expect(unpublished).toStrictEqual({
+        total: 1,
+        items: [expect.objectContaining(itemShape)]
+      });
+
+      const { body: updated } = await serverLimited
+        .get("/admin/rest/dashboard/updated")
+        .set(headersLimited)
+        .expect(200);
+      expect(updated).toStrictEqual({
+        total: 1,
+        items: [expect.objectContaining(itemShape)]
+      });
+
+      const { body: updatedByMe } = await serverLimited
+        .get("/admin/rest/dashboard/updated-by-user")
+        .set(headersLimited)
+        .expect(200);
+
+      expect(updatedByMe).toStrictEqual({
+        total: 1,
+        items: [expect.objectContaining(itemShape)]
+      });
+    });
+  });
+});

--- a/src/content/routes.ts
+++ b/src/content/routes.ts
@@ -54,6 +54,42 @@ export default (
     res.json(items);
   });
 
+  /** Dashboard routes  */
+
+  router.get("/admin/rest/dashboard/unpublished", async (req, res) => {
+    const { principal, query } = req;
+    const { limit = 50, offset = 0 } = query;
+
+    const items = await content.listUnpublishedContent(principal, {
+      limit,
+      offset
+    });
+    res.json(items);
+  });
+
+  router.get("/admin/rest/dashboard/updated", async (req, res) => {
+    const { query, principal } = req;
+    const { limit = 50, offset = 0 } = query;
+
+    const items = await content.listLastUpdatedContent(principal, {
+      limit,
+      offset
+    });
+    res.json(items);
+  });
+
+  router.get("/admin/rest/dashboard/updated-by-user", async (req, res) => {
+    const { principal, query } = req;
+    const { limit = 50, offset = 0 } = query;
+
+    const items = await content.listLastUpdatedContent(
+      principal,
+      { limit, offset },
+      true
+    );
+    res.json(items);
+  });
+
   /** List  */
   router.get("/admin/rest/content/:modelName", async (req, res) => {
     const { principal, params, query } = req;

--- a/src/persistence/adapter/index.ts
+++ b/src/persistence/adapter/index.ts
@@ -1,6 +1,6 @@
 import * as Cotype from "../../../typings";
 import { Migration } from "../ContentPersistence";
-import { Data, MetaData } from "../../../typings";
+import { Data, MetaData, ListOpts } from "../../../typings";
 
 type StoreAndSearchData = {
   storeData: Data;
@@ -110,6 +110,15 @@ export interface ContentAdapter {
       outstanding: Migration[]
     ) => Promise<void>
   ): Promise<any>;
+  listLastUpdatedContent(
+    models: string[],
+    opts: ListOpts,
+    user?: string
+  ): Promise<Cotype.ListChunk<Cotype.Content>>;
+  listUnpublishedContent(
+    models: string[],
+    opts: ListOpts
+  ): Promise<Cotype.ListChunk<Cotype.Content>>;
 }
 
 export interface MediaAdapter {


### PR DESCRIPTION
<img width="1440" alt="Dashboard" src="https://user-images.githubusercontent.com/27899554/62785848-b8990000-bac1-11e9-8ffb-f41f3b181990.png">


<!-- semantish-prerelease -->
<hr /><p><time>(8/14/2019, 1:33:17 PM)</date> Pre-released as <code>@cotype/core@1.29.0-beta.d5e5287</code></p>
<!-- /semantish-prerelease -->