### PR TITLE
fix[client: NumberInput]: add missing props for input of type number

### DIFF
--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -16,6 +16,8 @@ export type NumberType = {
   index?: boolean;
   search?: boolean;
   hidden?: boolean;
+  precision?: number;
+  step?: number;
 };
 export type RichtextType = {
   type: "richtext";


### PR DESCRIPTION
Add typings for `step` and `precision`.