### PR TITLE
feat[client: richtext]: add phone number as a link option

### DIFF
--- a/client/src/Edit/RichTextLinkModal.tsx
+++ b/client/src/Edit/RichTextLinkModal.tsx
@@ -5,15 +5,79 @@ import { Input } from "./elements";
 import Button from "../common/Button";
 import ModalDialog from "../common/ModalDialog";
 import { paths } from "../common/icons";
-import { Fields } from "../../../typings";
+import { Fields, RichtextType, UnionTypeTypes } from "../../../typings";
 import { parse } from "qs";
+import _pick from "lodash/pick";
 
 export const errorClass = "error-field-label";
+
+const types = {
+  link: {
+    type: "object",
+    label: "Link",
+    icon: "link-variant",
+    fields: {
+      link: {
+        type: "content",
+        models: [],
+        label: "Link",
+        allowAbsoluteRefs: true,
+        required: true
+      }
+    }
+  },
+  media: {
+    type: "object",
+    label: "Media",
+    icon: "image-outline",
+    fields: {
+      media: {
+        type: "media",
+        label: "Media",
+        required: true
+      }
+    }
+  },
+  mail: {
+    type: "object",
+    label: "E-Mail",
+    icon: "email-outline",
+    fields: {
+      email: {
+        type: "string",
+        label: "E-Mail Adresse",
+        required: true,
+        validationRegex:
+          '^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$',
+        regexError: "Has to be a valid e-mail address"
+      },
+      subject: {
+        type: "string",
+        label: "Betreff"
+      }
+    }
+  },
+  tel: {
+    type: "object",
+    label: "Telefon",
+    icon: "phone",
+    fields: {
+      phoneNumber: {
+        type: "string",
+        label: "Telefonnummer",
+        required: true,
+        validationRegex: "^\\+?[0-9]{3,}$",
+        regexError: "Has to be a valid phone number"
+      }
+    }
+  }
+};
 
 type Props = {
   onSave: (text: string, link: string | false) => void;
   onClose: () => void;
   initial: { text: string; link: string };
+  linkFormats: RichtextType["linkFormats"];
 };
 
 const modalDialogStyle = {
@@ -58,9 +122,18 @@ class RichTextLinkModal extends Component<Props> {
         (subject ? `?subject=${subject}` : "");
       this.props.onSave(values.text.trim(), link);
     }
+
+    if (
+      values.link[0].value._type === "tel" &&
+      values.link[0].value.phoneNumber
+    ) {
+      const link = "tel:" + values.link[0].value.phoneNumber;
+      this.props.onSave(values.text.trim(), link);
+    }
   };
 
   render() {
+    const { linkFormats = ["link", "mail", "media", "tel"] } = this.props;
     const model: Fields = {
       link: {
         label: "Verlinkung",
@@ -69,50 +142,7 @@ class RichTextLinkModal extends Component<Props> {
         maxLength: 1,
         item: {
           type: "union",
-          types: {
-            link: {
-              type: "object",
-              label: "Link",
-              fields: {
-                link: {
-                  type: "content",
-                  models: [],
-                  label: "Link",
-                  allowAbsoluteRefs: true,
-                  required: true
-                }
-              }
-            },
-            media: {
-              type: "object",
-              label: "Media",
-              fields: {
-                media: {
-                  type: "media",
-                  label: "Media",
-                  required: true
-                }
-              }
-            },
-            mail: {
-              type: "object",
-              label: "E-Mail",
-              fields: {
-                email: {
-                  type: "string",
-                  label: "E-Mail Adresse",
-                  required: true,
-                  validationRegex:
-                    '^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$',
-                  regexError: "Has to be a valid e-mail address"
-                },
-                subject: {
-                  type: "string",
-                  label: "Betreff"
-                }
-              }
-            }
-          }
+          types: _pick(types, linkFormats) as UnionTypeTypes
         }
       },
       text: {
@@ -134,14 +164,16 @@ class RichTextLinkModal extends Component<Props> {
         }
       : {};
 
-    const match = /\$intern:([\w]*):([0-9]*)\$/gm.exec(initial.link);
+    const internalLinkMatch = /\$intern:([\w]*):([0-9]*)\$/gm.exec(
+      initial.link
+    );
 
-    if (match) {
+    if (internalLinkMatch) {
       link.value = {
         _type: "link",
         link: {
-          model: match[1],
-          id: match[2]
+          model: internalLinkMatch[1],
+          id: internalLinkMatch[2]
         }
       };
     }
@@ -173,13 +205,23 @@ class RichTextLinkModal extends Component<Props> {
       };
     }
 
-    const initalValues = {
+    const telMatch = /tel:(\+?[0-9]{3,})/gm.exec(initial.link);
+
+    if (telMatch) {
+      link.value = {
+        _type: "tel",
+        phoneNumber: telMatch[1],
+        link: undefined
+      };
+    }
+
+    const initialValues = {
       text: initial.text,
       link: link.value ? [link] : []
     };
     return (
       <Formik
-        initialValues={initalValues}
+        initialValues={initialValues}
         validateOnChange={false}
         validateOnBlur={false}
         enableReinitialize

--- a/client/src/Edit/elements/RichTextInput.tsx
+++ b/client/src/Edit/elements/RichTextInput.tsx
@@ -107,15 +107,15 @@ export default class RichTextInput extends Component<Props> {
   closeLinkModal = () => this.setState({ open: false });
 
   render() {
-    const { field, formats, modules } = this.props;
+    const { field, formats, modules, linkFormats } = this.props;
     const { open, text, link } = this.state;
     let { value } = field;
     value = value ? value : this.defaultValue;
-
     return (
       <>
         {open && (
           <RichTextLinkModal
+            linkFormats={linkFormats}
             initial={{ text, link }}
             onSave={this.linkHandler}
             onClose={this.closeLinkModal}

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -19,10 +19,14 @@ export type NumberType = {
   precision?: number;
   step?: number;
 };
+
+type LinkOpts = "mail" | "media" | "link" | "tel";
+
 export type RichtextType = {
   type: "richtext";
   required?: boolean;
   formats?: any[][] | string[];
+  linkFormats?: LinkOpts[];
   modules?: {
     [key: string]: any;
   };


### PR DESCRIPTION
Add `tel` as a link option in the RichTextLinkModal component. Furthermore, add the possibility to specify which of those link options are allowed. 

Example: 
```
{
  type: "richtext",
  modules: {
    toolbar: [ ["link"] ]
  },
  linkFormats: ["mail", "link", "media", "tel"]
}
```
When`linkFormats` is not specified, all options are allowed.