### PR TITLE
feat(server): New Field Type, Virtual Fields with getter Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,4 +170,4 @@ or want to know more about what we consider "internal stuff", please refer
 to the [contribution guidelines](https://github.com/cotype/core/blob/master/CONTRIBUTING.md)
 
 
-.
+

--- a/client/src/Edit/elements/ObjectInput.tsx
+++ b/client/src/Edit/elements/ObjectInput.tsx
@@ -211,12 +211,17 @@ export default class ObjectInput extends Component<Props> {
               const f = fields[key];
               const { label: l, ...props } = f;
 
-              if ("hidden" in f || f.type === "references") return null;
+              if (
+                "hidden" in f ||
+                f.type === "references" ||
+                f.type === "virtual"
+              )
+                return null;
 
               const component = inputs.get(f);
               let label = l || titleCase(key);
 
-              if (typeof component.getHint === "function") {
+              if (component && typeof component.getHint === "function") {
                 const getHint = component.getHint(fields[key]);
                 if (getHint) label += ` ${getHint}`;
               }

--- a/client/src/Edit/elements/index.tsx
+++ b/client/src/Edit/elements/index.tsx
@@ -46,6 +46,8 @@ import inputs from "./inputs";
 import outputs from "./outputs";
 import PositionInput from "./PositionInput";
 
+const Empty: React.FC = () => null;
+
 inputs.register({
   boolean: BooleanInput,
   content: ReferenceInput,
@@ -64,7 +66,8 @@ inputs.register({
   date: DateInput,
   textarea: TextAreaInput,
   immutable: ImmutableInput,
-  position: PositionInput
+  position: PositionInput,
+  virtual: Empty
 });
 
 outputs.register({
@@ -83,7 +86,8 @@ outputs.register({
   date: DateOutput,
   textarea: TextOutput,
   immutable: ImmutableOutput,
-  position: TextOutput
+  position: TextOutput,
+  virtual: Empty
 });
 
 export const Input = ObjectInput;

--- a/client/src/Edit/elements/lists/Input.tsx
+++ b/client/src/Edit/elements/lists/Input.tsx
@@ -51,7 +51,7 @@ class Input extends Component<Props> {
     if (value && value.length) {
       value.forEach((item, idx) => {
         const component = inputs.get(props.item);
-        const error = component.validate(item.value, props.item);
+        const error = component && component.validate(item.value, props.item);
         if (error) errors[idx] = { value: error };
       });
 

--- a/client/src/common/ResultItem.tsx
+++ b/client/src/common/ResultItem.tsx
@@ -109,7 +109,11 @@ type BasicProps = {
 };
 export const BasicResultItem = ({ item, term }: BasicProps) => {
   const { title, image, kind } = item;
-  const src = image ? `/thumbs/square/${image}` : null;
+  const src = image
+    ? image.includes("://")
+      ? image
+      : `/thumbs/square/${image}`
+    : null;
   return (
     <ImageItem>
       <ImageCircle src={src} alt={title} size={12} />
@@ -117,7 +121,9 @@ export const BasicResultItem = ({ item, term }: BasicProps) => {
         <TitleWrapper>
           <ResultTitle title={title} term={term}></ResultTitle>
 
-          <Kind style={{ background: colorHash.hex(String(kind)) }}>{kind}</Kind>
+          <Kind style={{ background: colorHash.hex(String(kind)) }}>
+            {kind}
+          </Kind>
         </TitleWrapper>
         <DescriptionWrapper>
           {"description" in item && item.description && (

--- a/demo/models.ts
+++ b/demo/models.ts
@@ -270,6 +270,13 @@ export const models: ModelOpts[] = [
             singleTeaser
           }
         }
+      },
+      virtual: {
+        type: "virtual",
+        outputType: "string",
+        get: contentPage => {
+          return "Not saved in CMS, this is virtual " + contentPage.pagetitle;
+        }
       }
     }
   },

--- a/demo/models.ts
+++ b/demo/models.ts
@@ -187,6 +187,16 @@ export const models: ModelOpts[] = [
         type: "references",
         model: "contentPages",
         fieldName: "ref"
+      },
+      testObject:{
+        type:"object",
+        typeName:"TestObject",
+        fields:{
+          test:{
+            type:"string",
+            required:true
+          }
+        }
       }
     }
   },
@@ -276,6 +286,16 @@ export const models: ModelOpts[] = [
         outputType: "string",
         get: contentPage => {
           return "Not saved in CMS, this is virtual " + contentPage.pagetitle;
+        }
+      },
+      testObject:{
+        type:"object",
+        typeName:"TestObject",
+        fields:{
+          test:{
+            type:"string",
+            required:true
+          }
         }
       }
     }

--- a/src/api/oapi.ts
+++ b/src/api/oapi.ts
@@ -196,9 +196,18 @@ export function createDefinition(
     return {
       oneOf: Object.entries(model.types).map(([name, type]) => {
         const def = createDefinition(type, external, api);
-        _.set(def, "properties._type", { type: "string", enum: [name] });
-        _.set(def, "required", [...(def.required || []), "_type"]);
-        return def;
+        return {
+          allOf: [
+            def,
+            {
+              type: "object",
+              properties: {
+                _type: { type: "string", enum: [name] }
+              },
+              required: ["_type"]
+            }
+          ]
+        };
       }),
       discriminator: {
         propertyName: "_type"

--- a/src/api/oapi.ts
+++ b/src/api/oapi.ts
@@ -99,7 +99,12 @@ export function createDefinition(
         createDefinition(field, external)
       ),
       required: Object.entries(model.fields)
-        .map(([key, value]) => ((value as any).required ? key : null))
+        .map(([key, value]) =>
+          ((value as any).type === "virtual" && (value as any).get) ||
+          (value as any).required
+            ? key
+            : null
+        )
         .filter(Boolean) as string[]
     };
   }
@@ -122,8 +127,12 @@ export function createDefinition(
           _content: {
             type: "string",
             enum:
-              ('models' in model && model.models && model.models.length) || model.model
-                ? [...('models' in model && model.models || [model.model] || [])]
+              ("models" in model && model.models && model.models.length) ||
+              model.model
+                ? [
+                    ...(("models" in model && model.models) || [model.model] ||
+                      [])
+                  ]
                 : undefined
           },
           _url: { type: "string" }
@@ -197,6 +206,15 @@ export function createDefinition(
     return createDefinition(model.child, external);
   }
 
+  if (model.type === "virtual") {
+    if (!model.get) {
+      return empty;
+    }
+    return {
+      type: model.outputType
+    };
+  }
+
   return ref.schema(model.type);
 }
 
@@ -207,7 +225,12 @@ export function modelSchema(model: Model, external?: boolean) {
       createDefinition(field, external)
     ),
     required: Object.entries(model.fields)
-      .map(([key, value]) => ((value as any).required ? key : null))
+      .map(([key, value]) =>
+        ((value as any).type === "virtual" && (value as any).get) ||
+        (value as any).required
+          ? key
+          : null
+      )
       .filter(Boolean) as string[]
   };
 }

--- a/src/api/oapi.ts
+++ b/src/api/oapi.ts
@@ -116,7 +116,7 @@ export function createDefinition(
       } else {
         if (!isEqual(refs[typeName], schema)) {
           throw new Error(
-            `Object key "typeName" is used for different objects`
+            `Object key "typeName" is used for different element`
           );
         }
       }
@@ -209,13 +209,28 @@ export function createDefinition(
   if (model.type === "list") {
     if (external) return array(createDefinition(model.item, external, api));
 
-    return array({
+    const schema = array({
       type: "object",
       properties: {
         key: { type: "number" },
         value: createDefinition(model.item, external, api)
       }
     });
+    if (model.typeName) {
+      const typeName = toTypeName(model.typeName);
+      if (!refs[typeName]) {
+        api.addSchema(typeName, schema);
+        refs[typeName] = schema;
+      } else {
+        if (!isEqual(refs[typeName], schema)) {
+          throw new Error(
+            `List key "typeName" is used for different element`
+          );
+        }
+      }
+      return ref.schema(toTypeName(model.typeName));
+    }
+    return schema
   }
 
   if (model.type === "immutable") {

--- a/src/content/convert.ts
+++ b/src/content/convert.ts
@@ -4,7 +4,7 @@ import {
   Data,
   ContentRefs,
   PreviewOpts,
-  ContentFormat
+  ContentFormat, VirtualType
 } from "../../typings";
 import urlJoin from "url-join";
 import visit, { NO_STORE_VALUE } from "../model/visit";
@@ -185,6 +185,15 @@ export default function convert({
       field: { types: { [key: string]: object } }
     ) {
       if (!Object.keys(field.types).includes(data._type)) return null;
+    },
+    virtual(
+      _data,
+      field: VirtualType,
+    ) {
+      if(field.get){
+        return field.get(content)
+      }
+      return undefined
     }
   });
   return content;

--- a/src/content/rest/describe.ts
+++ b/src/content/rest/describe.ts
@@ -470,6 +470,10 @@ export default (api: OpenApiBuilder, models: Models) => {
   // Add models schemas
   const refs: { [key: string]: ReferenceObject } = {};
   models.content.forEach(model => {
+    if (model.collection === "iframe" || !model.noFeed) {
+      // Ignore iframe models & noFeed Models
+      return;
+    }
     refs[`${model.name}`] = addExternalModel(api, model);
   });
 
@@ -482,8 +486,8 @@ export default (api: OpenApiBuilder, models: Models) => {
     const singleton = collection === "singleton";
     const tags = [plural];
 
-    if (collection === "iframe") {
-      // Ignore iframe models
+    if (collection === "iframe" || !model.noFeed) {
+      // Ignore iframe models & noFeed Models
       return;
     }
 

--- a/src/content/rest/describe.ts
+++ b/src/content/rest/describe.ts
@@ -470,7 +470,7 @@ export default (api: OpenApiBuilder, models: Models) => {
   // Add models schemas
   const refs: { [key: string]: ReferenceObject } = {};
   models.content.forEach(model => {
-    if (model.collection === "iframe" || !model.noFeed) {
+    if (model.collection === "iframe" || model.noFeed) {
       // Ignore iframe models & noFeed Models
       return;
     }
@@ -486,7 +486,7 @@ export default (api: OpenApiBuilder, models: Models) => {
     const singleton = collection === "singleton";
     const tags = [plural];
 
-    if (collection === "iframe" || !model.noFeed) {
+    if (collection === "iframe" || model.noFeed) {
       // Ignore iframe models & noFeed Models
       return;
     }

--- a/src/content/rest/describe.ts
+++ b/src/content/rest/describe.ts
@@ -470,7 +470,7 @@ export default (api: OpenApiBuilder, models: Models) => {
   // Add models schemas
   const refs: { [key: string]: ReferenceObject } = {};
   models.content.forEach(model => {
-    if (model.collection === "iframe" || model.noFeed) {
+    if (model.collection === "iframe") {
       // Ignore iframe models & noFeed Models
       return;
     }

--- a/src/content/rest/routes.ts
+++ b/src/content/rest/routes.ts
@@ -172,7 +172,7 @@ export default function routes(
     });
 
     models
-      .filter(m => m.collection !== "iframe")
+      .filter(m => m.collection !== "iframe" && !m.noFeed)
       .forEach(model => {
         const type = model.name;
 

--- a/src/persistence/ContentPersistence.ts
+++ b/src/persistence/ContentPersistence.ts
@@ -569,8 +569,9 @@ export default class ContentPersistence implements Cotype.VersionedDataSource {
     opts: Cotype.ListOpts,
     previewOpts?: Cotype.PreviewOpts
   ): Promise<Cotype.ListChunk<Cotype.SearchResultItem>> {
+    const clearedTerm = term.replace("*", " ");
     const textSearch = await this.adapter.search(
-      term,
+      clearedTerm.length > 0 ? clearedTerm : " ",
       false,
       opts,
       previewOpts

--- a/typings/entities.d.ts
+++ b/typings/entities.d.ts
@@ -161,7 +161,7 @@ export type Data = {
   [field: string]: any;
 };
 
-export type DataRecord<T=Data> = Schedule & {
+export type DataRecord<T = Data> = Schedule & {
   id: string;
   data: T;
 };
@@ -178,7 +178,7 @@ export type RevisionRecord = {
   data: Data;
 };
 
-export type Content<T=Data> = DataRecord<T> & {
+export type Content<T = Data> = DataRecord<T> & {
   type: string;
   author: string;
   date: Date | string;

--- a/typings/entities.d.ts
+++ b/typings/entities.d.ts
@@ -161,9 +161,9 @@ export type Data = {
   [field: string]: any;
 };
 
-export type DataRecord = Schedule & {
+export type DataRecord<T=Data> = Schedule & {
   id: string;
-  data: Data;
+  data: T;
 };
 
 /**
@@ -178,7 +178,7 @@ export type RevisionRecord = {
   data: Data;
 };
 
-export type Content = DataRecord & {
+export type Content<T=Data> = DataRecord<T> & {
   type: string;
   author: string;
   date: Date | string;

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -1,3 +1,19 @@
+export type VirtualType = {
+  type: "virtual";
+} & (
+  | {
+      outputType: "string";
+      get: (fullModelData: any) => string;
+    }
+  | {
+      outputType: "number";
+      get: (fullModelData: any) => number;
+    }
+  | {
+      outputType: "boolean";
+      get: (fullModelData: any) => boolean;
+    }
+);
 export type BooleanType = {
   type: "boolean";
   input?: "checkbox" | "toggle";
@@ -222,7 +238,8 @@ export type Type =
   | ReferenceType
   | PositionType
   | ImmutableType
-  | InverseReferenceType;
+  | InverseReferenceType
+  | VirtualType;
 
 export type ModelOpts = {
   name: string;

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -247,6 +247,7 @@ export type ModelOpts = {
   plural?: string;
   collection?: "list" | "singleton" | "none" | "iframe";
   urlPath?: string;
+  noFeed?: true;
   fields?: {
     [key: string]: Field & { unique?: boolean };
   };

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -193,6 +193,7 @@ export type ListType = {
   maxLength?: number;
   layout?: "inline" | "block";
   hidden?: boolean;
+  typeName?: string;
 };
 
 export type UnionTypeType = ObjectType & { label?: string; icon?: string };

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -168,6 +168,7 @@ export type ObjectType = {
   fields: Fields;
   layout?: "vertical" | "horizontal" | "inline";
   modalView?: boolean;
+  typeName?: string;
 };
 
 export type MapKeyValue = { label: string; value: string } | string;


### PR DESCRIPTION
New Field:
`virtual: {
        type: "virtual",
        outputType: "string",
        get: contentPage => {
          return "Not saved in CMS, this is virtual " + contentPage.pagetitle;
        }
      }`

New Field will not be saved in Database, gets recreated on every Request

<!-- decorate-gh-pr -->
<hr /><p><em><date>[2020-06-09T12:03:12.053Z]</date></em> Pre-released:<br /><code>@cotype/core@1.39.0-feature-virtualField.1132346</code></p>
<!-- /decorate-gh-pr -->