### PR TITLE
Feature/fix media route permissions and slug flag

### DIFF
--- a/client/src/Edit/elements/SlugInput.tsx
+++ b/client/src/Edit/elements/SlugInput.tsx
@@ -5,7 +5,11 @@ import { Input } from "../../common/styles";
 import { required } from "./validation";
 import TextOutput from "./TextOutput";
 
-type Props = FieldProps<any> & { required?: boolean; id?:string };
+type Props = FieldProps<any> & {
+  required?: boolean;
+  id?: string;
+  alwaysEditable?: boolean;
+};
 export default class SlugInput extends Component<Props> {
   static getDefaultValue(props: Props) {
     return "";
@@ -22,12 +26,13 @@ export default class SlugInput extends Component<Props> {
   };
 
   render() {
-    const { field, form,id } = this.props;
+    const { field, form, id,alwaysEditable } = this.props;
     if (
       form.initialValues[field.name] === undefined ||
       form.initialValues[field.name] === null ||
       form.initialValues[field.name] === "" ||
-      id === undefined
+      id === undefined ||
+      alwaysEditable
     ) {
       const { value = "", ...props } = field;
       return (

--- a/demo/models.ts
+++ b/demo/models.ts
@@ -188,13 +188,13 @@ export const models: ModelOpts[] = [
         model: "contentPages",
         fieldName: "ref"
       },
-      testObject:{
-        type:"object",
-        typeName:"TestObject",
-        fields:{
-          test:{
-            type:"string",
-            required:true
+      testObject: {
+        type: "object",
+        typeName: "TestObject",
+        fields: {
+          test: {
+            type: "string",
+            required: true
           }
         }
       }
@@ -288,15 +288,26 @@ export const models: ModelOpts[] = [
           return "Not saved in CMS, this is virtual " + contentPage.pagetitle;
         }
       },
-      testObject:{
-        type:"object",
-        typeName:"TestObject",
-        fields:{
-          test:{
-            type:"string",
-            required:true
+      testObject: {
+        type: "object",
+        typeName: "TestObject",
+        fields: {
+          test: {
+            type: "string",
+            required: true
           }
         }
+      },
+      slugEditable: {
+        type: "string",
+        input: "slug",
+        label:"editable slug",
+        alwaysEditable: true
+      },
+      slug3: {
+        type: "string",
+        input: "slug",
+        label:"not editable slug"
       }
     }
   },

--- a/src/content/routes.ts
+++ b/src/content/routes.ts
@@ -59,6 +59,7 @@ export default (
 
     res.json(items);
   });
+  router.use("/admin/rest/externalDataSource", login);
   /** Search */
   router.get("/admin/rest/externalDataSource", async (req, res) => {
     const { principal, query } = req;
@@ -92,7 +93,7 @@ export default (
   });
 
   /** Dashboard routes  */
-
+  router.use("/admin/rest/dashboard", login);
   router.get("/admin/rest/dashboard/unpublished", async (req, res) => {
     const { principal, query } = req;
     const { limit = 50, offset = 0 } = query as any;

--- a/src/media/routes.ts
+++ b/src/media/routes.ts
@@ -8,6 +8,7 @@ import ReferenceConflictError from "../persistence/errors/ReferenceConflictError
 import inspect from "./inspect";
 import Storage from "./storage/Storage";
 import upload from "./upload";
+import login from "../auth/login";
 
 function isSvg(name: string) {
   return !!name.match(/[A-Za-z0-9_-]*\.*svg$/);
@@ -20,6 +21,7 @@ export default function routes(
   const { media } = persistence;
   const uploadHandler = upload(storage);
 
+  router.use("/admin/rest/upload", login);
   router.post("/admin/rest/upload", uploadHandler, async (req, res) => {
     const { principal, files: filesUpload } = req;
     const files: object[] = [];
@@ -73,6 +75,7 @@ export default function routes(
     res.json({ files, duplicates });
   });
 
+  router.use("/admin/rest/media", login);
   router.get("/admin/rest/media", async (req, res) => {
     const { principal, query } = req;
     const {

--- a/src/settings/routes.ts
+++ b/src/settings/routes.ts
@@ -6,6 +6,7 @@ import { Model } from "../../typings";
 import _ from "lodash";
 import { Router } from "express";
 import { Persistence } from "../persistence";
+import login from "../auth/login";
 
 export default (router: Router, persistence: Persistence, model: Model) => {
   const { settings } = persistence;
@@ -15,6 +16,7 @@ export default (router: Router, persistence: Persistence, model: Model) => {
     return _.pick(obj, Object.keys(fields));
   }
 
+  router.use(`/admin/rest/${modelType}`, login);
   /** List */
   router.get(`/admin/rest/${modelType}/${modelName}`, async (req: any, res) => {
     const { principal, query } = req;

--- a/typings/models.d.ts
+++ b/typings/models.d.ts
@@ -86,6 +86,7 @@ type Slug = {
   index?: boolean;
   search?: boolean;
   hidden?: boolean;
+  alwaysEditable?: boolean;
 };
 
 type DateString = {


### PR DESCRIPTION
Fix: require login permissions for admin routes. (media, settings, dashboard)
Feat: new flag for slug fields, "alwaysEditable"

<!-- decorate-gh-pr -->
<hr /><p><em><date>[2020-08-20T11:45:59.781Z]</date></em> Pre-released:<br /><code>@cotype/core@1.40.0-feature-fixMediaRoutePermissionsAndSlugFlag.1ed2673</code></p>
<!-- /decorate-gh-pr -->