### PR TITLE
docs: remove greenkeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@
   <a href="https://github.com/semantic-release/semantic-release">
     <img src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg" alt="semantic-release">
   </a>
-  <a href="https://greenkeeper.io/">
-    <img src="https://badges.greenkeeper.io/cotype/core.svg" alt="Greenkeeper">
-  </a>
 </p>
 <p>&nbsp;</p>
 


### PR DESCRIPTION
Sadly I won't have the time to continue contributing to cotype anymore :(

As a cleanup:

- I closed my trailing issues (feel free to also delete my experimental repos from the org)
- Removed all leftover greenkeeper branches, issues and PRs 
- `cotype.dev` will expire in a few weeks

I do still own @cotype-bot and [npm#cotype-bot](https://www.npmjs.com/~cotype-bot) if some of you want's to take over let me know.

